### PR TITLE
Sync triage-issues workflow among Homebrew repos

### DIFF
--- a/.github/workflows/sync-triage-config.yml
+++ b/.github/workflows/sync-triage-config.yml
@@ -1,0 +1,50 @@
+name: Sync triage configurations
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  sync-triage-config:
+    if: github.repository == 'Homebrew/.github'
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        repo:
+          - Homebrew/brew
+          - Homebrew/homebrew-core
+    steps:
+      - name: Clone main repository
+        uses: actions/checkout@v2
+        with:
+          persist-credentials: false
+
+      - name: Clone secondary repository
+        uses: actions/checkout@v2
+        with:
+          repository: ${{ matrix.repo }}
+          path: vendor/${{ matrix.repo }}
+          persist-credentials: false
+
+      - name: Configure Git user
+        uses: Homebrew/actions/git-user-config@master
+        with:
+          username: BrewTestBot
+
+      - name: Detect changes
+        id: detect_changes
+        run: ./.github/actions/sync/triage-config.rb 'vendor/${{ matrix.repo }}' '${{ matrix.repo }}' 'sync-triage-config'
+
+      - name: Create pull request
+        if: ${{ steps.detect_changes.outputs.pull_request == 'true' }}
+        uses: peter-evans/create-pull-request@8c603dbb04b917a9fc2dd991dc54fef54b640b43
+        with:
+          path: vendor/${{ matrix.repo }}
+          token: ${{ secrets.HOMEBREW_GITHUB_API_TOKEN }}
+          branch: sync-triage-config
+          title: Synchronize triage configuration.
+          body: >
+            This pull request was created automatically by the
+            [`sync-triage-config`](https://github.com/Homebrew/.github/blob/HEAD/.github/workflows/sync-triage-config.yml)
+            workflow.

--- a/.github/workflows/triage-issues.yml
+++ b/.github/workflows/triage-issues.yml
@@ -1,0 +1,50 @@
+# This file is synced from the `.github` repository, do not modify it directly.
+name: Triage issues
+
+on:
+  push:
+    paths:
+    - .github/workflows/triage-issues.yml
+  schedule:
+    # Once every day at midnight UTC
+    - cron: "0 0 * * *"
+  issue_comment:
+
+jobs:
+  stale:
+    if: >
+      startsWith(github.repository, 'Homebrew/') && (
+        github.event_name != 'issue_comment' || (
+          contains(github.event.issue.labels.*.name, 'stale') ||
+          contains(github.event.pull_request.labels.*.name, 'stale')
+        )
+      )
+    runs-on: ubuntu-latest
+    steps:
+      - name: Mark/Close Stale Issues and Pull Requests
+        uses: actions/stale@v3
+        with:
+          repo-token: ${{ secrets.HOMEBREW_GITHUB_API_TOKEN }}
+          days-before-stale: 21
+          days-before-close: 7
+          stale-issue-message: >
+            This issue has been automatically marked as stale because it has not had
+            recent activity. It will be closed if no further activity occurs.
+          stale-pr-message: >
+            This pull request has been automatically marked as stale because it has not had
+            recent activity. It will be closed if no further activity occurs.
+          exempt-issue-labels: 'gsoc-outreachy,help wanted,in progress'
+          exempt-pr-labels: 'gsoc-outreachy,help wanted,in progress'
+
+  lock-threads:
+    if: startsWith(github.repository, 'Homebrew/') && github.event_name != 'issue_comment'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Lock Outdated Threads
+        uses: dessant/lock-threads@63786a6c74ee3cfc4584f36de4360305c55e5126
+        with:
+          github-token: ${{ secrets.HOMEBREW_GITHUB_API_TOKEN }}
+          issue-lock-inactive-days: 30
+          issue-lock-labels: outdated
+          pr-lock-inactive-days: 30
+          pr-lock-labels: outdated

--- a/actions/sync/triage-config.rb
+++ b/actions/sync/triage-config.rb
@@ -1,0 +1,55 @@
+#!/usr/bin/env ruby
+
+require 'fileutils'
+require 'open3'
+require 'pathname'
+
+def git(*args)
+  system 'git', *args
+  exit $?.exitstatus unless $?.success?
+end
+
+target_dir = Pathname(ARGV[0])
+source_dir = ARGV[1]
+
+puts 'Detecting changes…'
+[
+  '.github/workflows/triage-issues.yml',
+].each do |glob|
+  src_paths = Pathname.glob(glob)
+  dst_paths = Pathname.glob(target_dir.join(glob))
+
+  dst_paths.each do |path|
+    FileUtils.rm_f path
+  end
+
+  src_paths.each do |path|
+    target_dir.join(path.dirname).mkpath
+    FileUtils.cp path, target_dir.join(path)
+  end
+end
+
+out, err, status = Open3.capture3('git', '-C', target_dir.to_s, 'status', '--porcelain', '--ignore-submodules=dirty')
+raise err unless status.success?
+
+target_dir_changed = !out.chomp.empty?
+
+unless target_dir_changed
+  puts 'No changed detected.'
+  exit
+end
+
+git '-C', target_dir.to_s, 'add', '--all'
+
+out, err, status = Open3.capture3('git', '-C', target_dir.to_s, 'diff', '--name-only', '--staged')
+raise err unless status.success?
+
+modified_paths = out.lines.map(&:chomp)
+
+modified_paths.each do |modified_path|
+  puts "Detected changes to #{modified_path}."
+  git '-C', target_dir.to_s, 'commit', modified_path, '--message', "#{File.basename(modified_path)}: update to match main configuration", '--quiet'
+end
+puts
+
+puts '::set-output name=pull_request::true'


### PR DESCRIPTION
This PR adds two workflow to the `.github` repository.

The first is the new `triage-issues` workflow that will be used to triage issues for the Homebrew organization. This includes marking issues as stale and locking old issues. This will be a replacement for the existing [stale bot](https://github.com/Homebrew/.github/blob/master/.github/stale.yml) and [lock bot](https://github.com/Homebrew/.github/blob/master/.github/lock.yml) which are both inactive. This has been discussed previously on Slack, in https://github.com/Homebrew/homebrew-core/pull/65631, and https://github.com/Homebrew/brew/pull/9368.

The second is a new `sync-triage-config` workflow. This workflow will sync the changes made to the `triage-issues` workflow in this repo to all of the other repos in the organization that use it. This is heavily adapted from cask's [`sync-templates-and-ci-config`](https://github.com/Homebrew/homebrew-cask/blob/master/.github/workflows/sync-templates-and-ci-config.yml) workflow.

Once this is merged, changes can be made to the `triage-issues` workflow organization-wide by merging a PR here modifying the workflow. The `sync-triage-config` workflow will then open PRs making the same change in all necessary repos.

At the moment, I've only enabled this for Homebrew/homebrew-core and Homebrew/brew. Once it appears that this is working, I'll add more repos (I have a list written down in my notes). I want to avoid opening PRs in several repos if there's an issue.

I've done some preliminary testing in three personal repos: [Rylan12/homebrew-sync-test](https://github.com/Rylan12/homebrew-sync-test) (the root repo), [Rylan12/homebrew-sync-test1](https://github.com/Rylan12/homebrew-sync-test1), and [Rylan12/homebrew-sync-test2](https://github.com/Rylan12/homebrew-sync-test2). Feel free to check those out to see how it works.

CC: @MikeMcQuaid and @reitermarkus
