### PR TITLE
sync-triage-config: add organization repos

### DIFF
--- a/.github/workflows/sync-triage-config.yml
+++ b/.github/workflows/sync-triage-config.yml
@@ -13,7 +13,20 @@ jobs:
       matrix:
         repo:
           - Homebrew/brew
+          - Homebrew/brew.sh
+          - Homebrew/formula-patches
+          - Homebrew/formulae.brew.sh
+          - Homebrew/gsoc
+          - Homebrew/homebrew-aliases
+          - Homebrew/homebrew-cask
+          - Homebrew/homebrew-cask-drivers
+          - Homebrew/homebrew-cask-fonts
+          - Homebrew/homebrew-cask-versions
+          - Homebrew/homebrew-command-not-found
           - Homebrew/homebrew-core
+          - Homebrew/homebrew-portable-ruby
+          - Homebrew/homebrew-test-bot
+          - Homebrew/install
     steps:
       - name: Clone main repository
         uses: actions/checkout@v2
@@ -43,7 +56,7 @@ jobs:
           path: vendor/${{ matrix.repo }}
           token: ${{ secrets.HOMEBREW_GITHUB_API_TOKEN }}
           branch: sync-triage-config
-          title: Synchronize triage configuration.
+          title: Synchronize triage configuration
           body: >
             This pull request was created automatically by the
             [`sync-triage-config`](https://github.com/Homebrew/.github/blob/HEAD/.github/workflows/sync-triage-config.yml)


### PR DESCRIPTION
This PR adds the remaining repositories in the Homebrew organization to the `sync-triage-config` workflow. This means that PRs will automatically be opened in these repos whenever the `triage-issues` workflow is modified here.

A few notes:

- I didn't add `Homebrew/linuxbrew-core` as I think they will get these changes via their regular Homebrew/homebrew-core merges.
- I didn't add `Homebrew/actions` to this list. I think it's the only major repo we have isn't on the list. It doesn't currently have any stale bots or anything set up, but if we'd like to add it I can do so. This may be a question for @jonchang.
- I added the `Homebrew/Homebrew-cask` and `Homebrew/Homebrew-cask-*` repos to this list as well. @Homebrew/cask maintainers, please let me know if you would rather I didn't add these repos. Alternatively, I can add only `Homebrew/homebrew-cask` and the `triage-issues` workflow can be added to the cask [`sync-templates-and-ci-config`](https://github.com/Homebrew/homebrew-cask/blob/master/.github/workflows/sync-templates-and-ci-config.yml) workflow to sync among the cask repos.

Lastly, when these PRs are opened, they should probably be modified to remove the old, unused bot configuration files that likely still exist in their `.github` directories. These include `lock.yml`, `no-response.yml`, `stale.yml`, `support.yml`. If not done in the same PR, I'll likely open a follow-up PR to remove them.