### PR TITLE
workflows/sync-triage-config: sync more repos

### DIFF
--- a/.github/workflows/sync-triage-config.yml
+++ b/.github/workflows/sync-triage-config.yml
@@ -12,21 +12,27 @@ jobs:
     strategy:
       matrix:
         repo:
+          - Homebrew/actions
           - Homebrew/brew
           - Homebrew/brew.sh
           - Homebrew/formula-patches
           - Homebrew/formulae.brew.sh
           - Homebrew/gsoc
           - Homebrew/homebrew-aliases
+          - Homebrew/homebrew-bundle
           - Homebrew/homebrew-cask
           - Homebrew/homebrew-cask-drivers
           - Homebrew/homebrew-cask-fonts
           - Homebrew/homebrew-cask-versions
           - Homebrew/homebrew-command-not-found
           - Homebrew/homebrew-core
+          - Homebrew/homebrew-formula-analytics
           - Homebrew/homebrew-portable-ruby
+          - Homebrew/homebrew-services
           - Homebrew/homebrew-test-bot
           - Homebrew/install
+          - Homebrew/ruby-macho
+          - Homebrew/rubydoc.brew.sh
     steps:
       - name: Clone main repository
         uses: actions/checkout@v2


### PR DESCRIPTION
Add `Homebrew/homebrew-formula-analytics` and `Homebrew/rubydoc.brew.sh` to the list of repos to sync.

CC: @MikeMcQuaid
