### PR TITLE
Add dependabot configuration for GitHub actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+
+updates:
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly


### PR DESCRIPTION
There have been two new releases of the [lock-threads](https://github.com/dessant/lock-threads) since this was last updated.

I don't know how often we want to update these. I'm partially opening this PR to discuss this. In this particular case, there are two changes:

1. update imported package name (https://github.com/dessant/lock-threads/commit/eba004bec39a410184db347eec5294ca57d38188)
1. update dependencies (https://github.com/dessant/lock-threads/commit/eb0aabb42c66b0d8f954cbceabe5809170095a9a)

Both of these seem legitimate to me, but it also doesn't seem like it fixes any bugs or adds any new features. I think the only concern is whether or not we want to update the version in all repos (which would require merging PRs in all of those).

Because of that, I'm kind of leaning toward not-merging this PR, but I would like to propose some (unofficial) guidelines for when this _should_ be updated:

- When a new major/minor version of the action is released
- When a patch release fixes a bug that we are experiencing
- If a patch release adds new functionality that we want to start using

We should _not_ update:

- If a major/minor/patch release is suspicious in any way (e.g. major changes that seem to remove core functionality or indicate malicious intentions)
- Patch releases that make insignificant or non-bug-fix changes (e.g. updating dependencies)

_This discussion is probably better suited for an issue but issues are disabled here so I'm doing a PR instead :smile:_
