### PR TITLE
workflows/sync-triage-config: sign commits

### DIFF
--- a/.github/workflows/sync-triage-config.yml
+++ b/.github/workflows/sync-triage-config.yml
@@ -50,8 +50,15 @@ jobs:
         with:
           username: BrewTestBot
 
+      - name: Set up GPG commit signing
+        uses: Homebrew/actions/setup-commit-signing@master
+        with:
+          signing_key: ${{ secrets.BREWTESTBOT_GPG_SIGNING_SUBKEY }}
+
       - name: Detect changes
         id: detect_changes
+        env:
+          HOMEBREW_GPG_PASSPHRASE: ${{ secrets.BREWTESTBOT_GPG_SIGNING_SUBKEY_PASSPHRASE }}
         run: ./.github/actions/sync/triage-config.rb 'vendor/${{ matrix.repo }}' '${{ matrix.repo }}' 'sync-triage-config'
 
       - name: Create pull request


### PR DESCRIPTION
Sign the synchronization commits in PRs opened by the `sync-triage-config` workflow.

The `BREWTESTBOT_GPG_SIGNING_SUBKEY` and `BREWTESTBOT_GPG_SIGNING_SUBKEY_PASSPHRASE` secrets will need to be added to this repo if they're not already accessible.

CC: @MikeMcQuaid and @Bo98
