### PR TITLE
triage-issues: add stale configuration for `bump-*-pr` labels

### DIFF
--- a/.github/workflows/triage-issues.yml
+++ b/.github/workflows/triage-issues.yml
@@ -36,6 +36,29 @@ jobs:
           exempt-issue-labels: "gsoc-outreachy,help wanted,in progress"
           exempt-pr-labels: "gsoc-outreachy,help wanted,in progress"
 
+  bump-pr-stale:
+    if: >
+      startsWith(github.repository, 'Homebrew/') && (
+        github.event_name != 'issue_comment' || (
+          contains(github.event.issue.labels.*.name, 'stale') ||
+          contains(github.event.pull_request.labels.*.name, 'stale')
+        )
+      )
+    runs-on: ubuntu-latest
+    steps:
+      - name: Mark/Close Stale `bump-formula-pr` and `bump-cask-pr` Pull Requests
+        uses: actions/stale@v3.0.18
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          days-before-stale: 2
+          days-before-close: 1
+          stale-pr-message: >
+            This pull request has been automatically marked as stale because it has not had
+            recent activity. It will be closed if no further activity occurs. To keep this
+            pull request open, add a `help wanted` or `in progress` label.
+          exempt-pr-labels: "help wanted,in progress"
+          any-of-labels: "bump-formula-pr,bump-cask-pr"
+
   lock-threads:
     if: startsWith(github.repository, 'Homebrew/') && github.event_name != 'issue_comment'
     runs-on: ubuntu-latest


### PR DESCRIPTION
Closes https://github.com/Homebrew/homebrew-core/issues/76763

This PR adds a stale configuration that will handle PRs labeled with `bump-formula-pr` or `bump-cask-pr`. They will be marked stale after 48 hours, and closed after an additional 24 hours. When marked as stale, the following message will be left:

> This pull request has been automatically marked as stale because it has not had recent activity. It will be closed if no further activity occurs. To keep this pull request open, add a `help wanted` or `in progress` label.

Right now, this message doesn't reference the `bump-*-pr` label that caused it to be marked as stale earlier than a typical PR. Is that okay? Also, this currently uses the same `stale` label that is used by the regular stale action. I think this is fine because this new configuration has will close things more quickly, but a potential downside is that the existing configuration would have to check all PRs marked as `stale` by the new configuration to see if they're old enough to close. I don't think this will be a problem, though, as most PRs should be merged before either stale configuration is triggered.
