### PR TITLE
dependabot: change update interval to "daily"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,4 +5,4 @@ updates:
   - package-ecosystem: github-actions
     directory: /
     schedule:
-      interval: weekly
+      interval: daily


### PR DESCRIPTION
See https://github.com/Homebrew/brew/issues/11401

There's no reason to limit this to `weekly` when each repo will check `daily`
