### PR TITLE
sync-triage-config: add Homebrew/homebrew-json to synced repos

### DIFF
--- a/.github/workflows/sync-triage-config.yml
+++ b/.github/workflows/sync-triage-config.yml
@@ -27,6 +27,7 @@ jobs:
           - Homebrew/homebrew-command-not-found
           - Homebrew/homebrew-core
           - Homebrew/homebrew-formula-analytics
+          - Homebrew/homebrew-json
           - Homebrew/homebrew-portable-ruby
           - Homebrew/homebrew-services
           - Homebrew/homebrew-test-bot


### PR DESCRIPTION
Sync the Homebrew/homebrew-json repo
