### PR TITLE
Don't try to sync the triage-issues workflow with Homebrew/homebrew-json

### DIFF
--- a/.github/workflows/sync-triage-config.yml
+++ b/.github/workflows/sync-triage-config.yml
@@ -35,7 +35,6 @@ jobs:
           - Homebrew/homebrew-command-not-found
           - Homebrew/homebrew-core
           - Homebrew/homebrew-formula-analytics
-          - Homebrew/homebrew-json
           - Homebrew/homebrew-portable-ruby
           - Homebrew/homebrew-services
           - Homebrew/homebrew-test-bot


### PR DESCRIPTION
`Homebrew/homebrew-json` has been removed so let's not try to sync `triage-issues.yml` to it anymore.
