### PR TITLE
triage-issues: close issues/PRs as "not planned"

### DIFF
--- a/.github/workflows/triage-issues.yml
+++ b/.github/workflows/triage-issues.yml
@@ -37,6 +37,7 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           days-before-stale: 21
           days-before-close: 7
+          close-issue-reason: "not_planned"
           stale-issue-message: >
             This issue has been automatically marked as stale because it has not had
             recent activity. It will be closed if no further activity occurs.


### PR DESCRIPTION
`actions/stale` supports settings close issue reason since [v5.1.0](https://github.com/actions/stale/releases/tag/v5.1.0). I suggest marking such issues as ["not planned"](https://github.blog/changelog/2022-03-10-the-new-github-issues-march-10th-update/#%F0%9F%95%B5%F0%9F%8F%BD%E2%99%80%EF%B8%8F-issue-closed-reasons) to distinguish them in UI easily.