### PR TITLE
SECURITY: Copy and augment policy that we had on HackerOne

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,5 +1,19 @@
 # Security Policy
 
+No technology is perfect, and Homebrew believes that working with skilled security researchers across the globe is crucial in identifying weaknesses in any technology. If you believe you've found a security issue in Homebrew, we encourage you to notify us. We welcome working with you to resolve the issue promptly. Thank you for keeping Homebrew and its users safe!
+
+## Disclosure Policy
+
+Let us know as soon as possible upon discovery of a potential security issue, and we'll make every effort to quickly resolve the issue. Please bear in mind we're a project run entirely by volunteers in our spare time.
+
+Make a good faith effort to avoid privacy violations, destruction of data, and interruption or degradation of our service. Only interact with accounts you own or with our explicit permission.
+
+See the ["Security" section of our README](https://github.com/Homebrew/brew/blob/master/README.md#security) for instructions on how to report a security vulnerability.
+
+If it's a straightforward fix: please submit a pull request on GitHub.
+
+We will respond to and fix reported, reproducible security vulnerabilities as soon as possible. A gentle reminder that we are a volunteer-run project so please cut us some slack here. Provide us a reasonable amount of time to resolve the issue before any disclosure to the public or a third-party.
+
 ## Supported Versions
 
 Homebrew is a rolling release package manager. This means:
@@ -7,8 +21,28 @@ Homebrew is a rolling release package manager. This means:
 - only the latest release and latest commit on the `master` branch of Homebrew/brew are supported.
 - only the latest commit on the `master` branch of all Homebrew repositories is supported.
 
-## Reporting a Vulnerability
+## Scope
 
-See the ["Security" section of our README](https://github.com/Homebrew/brew/blob/master/README.md#security) for instructions on how to support a security vulnerability.
+The following sites and applications are within scope for this program:
 
-We will respond to and fix reported, reproducible security vulnerabilities as soon as possible. A gentle reminder that we are a volunteer-run project so please cut us some slack here.
+- The brew package manager (Homebrew/brew)
+- The Homebrew/homebrew-* official taps
+
+## Exclusions
+
+The following do not constitute security vulnerabilities in Homebrew:
+
+- brew.sh websites
+- brew.sh domain SPF configuration
+- security vulnerabilities in hosted web services Homebrew relies on (e.g. GitHub, Google Analytics, GitHub Pages)
+- security vulnerabilities in packaged software that are present in the upstream software (although these should be reported to the upstream software)
+- security vulnerabilities in software used by but not written by Homebrew
+- nominal clickjacking and similar attacks against our static, GitHub Pages websites
+
+While researching, we'd like to ask you to refrain from:
+
+- Denial of service
+- Spamming
+- Social engineering (including phishing) of Homebrew maintainers or contributors
+- Any physical attempts against Homebrew's machines
+


### PR DESCRIPTION
- This info was on HackerOne and we're moving towards having everything in GitHub. Let's add all the policy wording we had there in here so that researchers can find it more easily and know what is (not) in scope.
- Related PR: https://github.com/Homebrew/brew/pull/14132.