### PR TITLE
Don't sync to `homebrew/cask-drivers`.

### DIFF
--- a/.github/workflows/sync-triage-config.yml
+++ b/.github/workflows/sync-triage-config.yml
@@ -29,7 +29,6 @@ jobs:
           - Homebrew/homebrew-autoupdate
           - Homebrew/homebrew-bundle
           - Homebrew/homebrew-cask
-          - Homebrew/homebrew-cask-drivers
           - Homebrew/homebrew-cask-fonts
           - Homebrew/homebrew-cask-versions
           - Homebrew/homebrew-command-not-found


### PR DESCRIPTION
Tap will be deprecated soon.