### PR TITLE
Fixes for deprecated repos etc.

### DIFF
--- a/.github/workflows/sync-triage-config.yml
+++ b/.github/workflows/sync-triage-config.yml
@@ -24,12 +24,10 @@ jobs:
           - Homebrew/brew.sh
           - Homebrew/formula-patches
           - Homebrew/formulae.brew.sh
-          - Homebrew/gsoc
           - Homebrew/homebrew-aliases
           - Homebrew/homebrew-autoupdate
           - Homebrew/homebrew-bundle
           - Homebrew/homebrew-cask
-          - Homebrew/homebrew-cask-drivers
           - Homebrew/homebrew-cask-fonts
           - Homebrew/homebrew-cask-versions
           - Homebrew/homebrew-command-not-found
@@ -41,6 +39,7 @@ jobs:
           - Homebrew/install
           - Homebrew/ruby-macho
           - Homebrew/rubydoc.brew.sh
+      fail-fast: false
     steps:
       - name: Clone main repository
         uses: actions/checkout@v4

--- a/.github/workflows/triage-issues.yml
+++ b/.github/workflows/triage-issues.yml
@@ -23,7 +23,7 @@ concurrency:
 jobs:
   stale:
     if: >
-      startsWith(github.repository, 'Homebrew/') && (
+      github.repository_owner == 'Homebrew' && (
         github.event_name != 'issue_comment' || (
           contains(github.event.issue.labels.*.name, 'stale') ||
           contains(github.event.pull_request.labels.*.name, 'stale')
@@ -48,7 +48,7 @@ jobs:
 
   bump-pr-stale:
     if: >
-      startsWith(github.repository, 'Homebrew/') && (
+      github.repository_owner == 'Homebrew' && (
         github.event_name != 'issue_comment' || (
           contains(github.event.issue.labels.*.name, 'stale') ||
           contains(github.event.pull_request.labels.*.name, 'stale')
@@ -70,13 +70,14 @@ jobs:
           any-of-labels: "bump-formula-pr,bump-cask-pr"
 
   lock-threads:
-    if: startsWith(github.repository, 'Homebrew/') && github.event_name != 'issue_comment'
+    if: github.repository_owner == 'Homebrew' && github.event_name != 'issue_comment'
     runs-on: ubuntu-latest
     steps:
       - name: Lock Outdated Threads
         uses: dessant/lock-threads@1bf7ec25051fe7c00bdd17e6a7cf3d7bfb7dc771
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          process-only: 'issues, prs'
           issue-inactive-days: 30
           add-issue-labels: outdated
           pr-inactive-days: 30


### PR DESCRIPTION
* [workflows/sync-triage-config: remove deprecated repos](https://github.com/Homebrew/.github/commit/a3ec1bd88aaec3cfce59bfdf662db3042f4ec153)
  - Remove Homebrew/gsoc (archived)
  - Remove Homebrew/homebrew-cask-drivers (archived soon, probably). Current maintainers are been rejecting these PRs anyway.
  - Don't fail fast as we want to sync to as many repos as possible, and ideally not cut off any between push and PR creation.
* [workflows/triage-issues: don't check discussions](https://github.com/Homebrew/.github/commit/76b1acbef83cb5f6ace944f0efd96e0d5e971693)
  - Adapt for breaking v5 change: #88
  - This didn't actually matter in terms of locking behaviour since we don't sync to Homebrew/discussions, but search API rate limits are at a premium and it's worth saving on those where possible.