### PR TITLE
SECURITY: make conduct section, warn against weaponized PRs

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -39,10 +39,12 @@ The following do not constitute security vulnerabilities in Homebrew:
 - security vulnerabilities in software used by but not written by Homebrew
 - nominal clickjacking and similar attacks against our static, GitHub Pages websites
 
-While researching, we'd like to ask you to refrain from:
+## Conduct
+
+While researching, we ask you to refrain from:
 
 - Denial of service
 - Spamming
 - Social engineering (including phishing) of Homebrew maintainers or contributors
 - Any physical attempts against Homebrew's machines
-
+- Testing discoveries on Homebrew's CI/CD or other services by filing public PRs containing weaknesses

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -47,4 +47,4 @@ While researching, we ask you to refrain from:
 - Spamming
 - Social engineering (including phishing) of Homebrew maintainers or contributors
 - Any physical attempts against Homebrew's machines
-- Testing discoveries on Homebrew's CI/CD or other services by filing public PRs containing weaknesses
+- Performing vulnerability research in public, such as testing discoveries by opening pull requests to Homebrew's public repositories without prior written approval


### PR DESCRIPTION
Per Slack discussion: researchers are sometimes tempted to submit public PRs containing pentesting/partially proven-out exploits. We should discourage that explicitly.

(Language is not settled here, please aggressively nitpick!)

CC @p-linnane @Bo98 