### PR TITLE
split locking threads and stale issue cleanup

### DIFF
--- a/.github/workflows/lock-threads.yml
+++ b/.github/workflows/lock-threads.yml
@@ -1,0 +1,36 @@
+# This file is synced from the `.github` repository, do not modify it directly.
+name: Lock threads
+
+on:
+  push:
+    paths:
+      - .github/workflows/lock-threads.yml
+    branches-ignore:
+      - dependabot/**
+  schedule:
+    # Once every day at 1am UTC
+    - cron: "0 1 * * *"
+  issue_comment:
+
+permissions:
+  issues: write
+  pull-requests: write
+
+concurrency:
+  group: lock-threads
+  cancel-in-progress: ${{ github.event_name != 'issue_comment' }}
+
+jobs:
+  lock-threads:
+    if: github.repository_owner == 'Homebrew' && github.event_name != 'issue_comment'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Lock Outdated Threads
+        uses: dessant/lock-threads@1bf7ec25051fe7c00bdd17e6a7cf3d7bfb7dc771
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          process-only: 'issues, prs'
+          issue-inactive-days: 30
+          add-issue-labels: outdated
+          pr-inactive-days: 30
+          add-pr-labels: outdated

--- a/.github/workflows/stale-issues.yml
+++ b/.github/workflows/stale-issues.yml
@@ -1,10 +1,10 @@
 # This file is synced from the `.github` repository, do not modify it directly.
-name: Triage issues
+name: Manage stale issues
 
 on:
   push:
     paths:
-      - .github/workflows/triage-issues.yml
+      - .github/workflows/stale-issues.yml
     branches-ignore:
       - dependabot/**
   schedule:
@@ -17,7 +17,7 @@ permissions:
   pull-requests: write
 
 concurrency:
-  group: triage-issues
+  group: stale-issues
   cancel-in-progress: ${{ github.event_name != 'issue_comment' }}
 
 jobs:
@@ -68,17 +68,3 @@ jobs:
             pull request open, add a `help wanted` or `in progress` label.
           exempt-pr-labels: "help wanted,in progress"
           any-of-labels: "bump-formula-pr,bump-cask-pr"
-
-  lock-threads:
-    if: github.repository_owner == 'Homebrew' && github.event_name != 'issue_comment'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Lock Outdated Threads
-        uses: dessant/lock-threads@1bf7ec25051fe7c00bdd17e6a7cf3d7bfb7dc771
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          process-only: 'issues, prs'
-          issue-inactive-days: 30
-          add-issue-labels: outdated
-          pr-inactive-days: 30
-          add-pr-labels: outdated


### PR DESCRIPTION
Some of the repositories are starting to [hit GitHub rate limits due to running the tasks sequentially](https://github.com/Homebrew/homebrew-bundle/actions/runs/8515410691).

These aren't that time sensitive so instead, we can split them into multiple jobs that run an hour apart.