### PR TITLE
actions/sync/triage-config: add new workflow paths

### DIFF
--- a/.github/actions/sync/triage-config.rb
+++ b/.github/actions/sync/triage-config.rb
@@ -14,6 +14,8 @@ source_dir = ARGV[1]
 
 puts 'Detecting changes…'
 [
+  '.github/workflows/lock-threads.yml',
+  '.github/workflows/stale-issues.yml',
   '.github/workflows/triage-issues.yml',
 ].each do |glob|
   src_paths = Pathname.glob(glob)


### PR DESCRIPTION
The sync triage workflow opened PRs to remove the workflows from the other repos, because the new paths are not found here.

Example: https://github.com/Homebrew/homebrew-cask-versions/pull/19868/files