### PR TITLE
triage-config.rb: update workflows to sync

### DIFF
--- a/.github/actions/sync/triage-config.rb
+++ b/.github/actions/sync/triage-config.rb
@@ -14,7 +14,8 @@ source_dir = ARGV[1]
 
 puts 'Detecting changes…'
 [
-  '.github/workflows/triage-issues.yml',
+  '.github/workflows/lock-threads.yml',
+  '.github/workflows/stale-issues.yml',
 ].each do |glob|
   src_paths = Pathname.glob(glob)
   dst_paths = Pathname.glob(target_dir.join(glob))


### PR DESCRIPTION
Companion to #97. This makes sure the renamed workflows are properly synced to Homebrew repos.
