### PR TITLE
triage-config: keep old path

### DIFF
--- a/.github/actions/sync/triage-config.rb
+++ b/.github/actions/sync/triage-config.rb
@@ -16,6 +16,7 @@ puts 'Detecting changes…'
 [
   '.github/workflows/lock-threads.yml',
   '.github/workflows/stale-issues.yml',
+  '.github/workflows/triage-issues.yml',
 ].each do |glob|
   src_paths = Pathname.glob(glob)
   dst_paths = Pathname.glob(target_dir.join(glob))


### PR DESCRIPTION
I think we need to retain the old `triage-issue` path to ensure it is removed from the other repos. Unless we manually remove it.

CC: @MikeMcQuaid