### PR TITLE
Revert "triage-config: keep old path"

### DIFF
--- a/.github/actions/sync/triage-config.rb
+++ b/.github/actions/sync/triage-config.rb
@@ -16,7 +16,6 @@ puts 'Detecting changes…'
 [
   '.github/workflows/lock-threads.yml',
   '.github/workflows/stale-issues.yml',
-  '.github/workflows/triage-issues.yml',
 ].each do |glob|
   src_paths = Pathname.glob(glob)
   dst_paths = Pathname.glob(target_dir.join(glob))

--- a/.github/workflows/sync-triage-config.yml
+++ b/.github/workflows/sync-triage-config.yml
@@ -25,7 +25,6 @@ jobs:
           - Homebrew/formula-patches
           - Homebrew/formulae.brew.sh
           - Homebrew/homebrew-aliases
-          - Homebrew/homebrew-autoupdate
           - Homebrew/homebrew-bundle
           - Homebrew/homebrew-cask
           - Homebrew/homebrew-cask-fonts


### PR DESCRIPTION
Reverts #100

The workflow has been synced to all repos, so it's safe to remove it from the list now.

Also, remove Homebrew/homebrew-autoupdate from the list of repos to sync as the tap is no longer official.
