### PR TITLE
Revert "workflows/sync-shared-config: add mass-bottling-tracker."

### DIFF
--- a/.github/workflows/sync-shared-config.yml
+++ b/.github/workflows/sync-shared-config.yml
@@ -40,7 +40,6 @@ jobs:
           - Homebrew/homebrew-services
           - Homebrew/homebrew-test-bot
           - Homebrew/install
-          - Homebrew/mass-bottling-tracker
           - Homebrew/orka_api_client
           - Homebrew/ruby-macho
           - Homebrew/rubydoc.brew.sh


### PR DESCRIPTION
Reverts Homebrew/.github#108