### PR TITLE
sync/shared-config: tweak rubocop.

### DIFF
--- a/.github/workflows/sync-shared-config.yml
+++ b/.github/workflows/sync-shared-config.yml
@@ -82,6 +82,11 @@ jobs:
         with:
           signing_key: ${{ secrets.BREWTESTBOT_GPG_SIGNING_SUBKEY }}
 
+      - name: Install Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+
       - name: Detect changes
         id: detect_changes
         env:


### PR DESCRIPTION
- Use different source file from Homebrew/brew.
- Reject lines that don't make sense.
- Install and use the appropriate Ruby version.