### PR TITLE
Further improve shared configuration syncing

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,49 @@
+# This file is synced from the `.github` repository, do not modify it directly.
 version: 2
 
 updates:
-
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: daily
+    allow:
+      - dependency-type: all
+    # The actions in triage-issues.yml are updated in the Homebrew/.github repo
+    ignore:
+      - dependency-name: actions/stale
+      - dependency-name: dessant/lock-threads
+
+  - package-ecosystem: bundler
+    directory: /
+    schedule:
+      interval: daily
+    allow:
+      - dependency-type: all
+
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: daily
+    allow:
+      - dependency-type: all
+
+  - package-ecosystem: docker
+    directory: /
+    schedule:
+      interval: daily
+    allow:
+      - dependency-type: all
+
+  - package-ecosystem: devcontainers
+    directory: /
+    schedule:
+      interval: daily
+    allow:
+      - dependency-type: all
+
+  - package-ecosystem: pip
+    directory: /
+    schedule:
+      interval: daily
+    allow:
+      - dependency-type: all


### PR DESCRIPTION
- Also sync a decent, default, comprehensive Dependabot configuration
- Allow opt-out for custom RuboCop and Dependabot configurations