### PR TITLE
sync/shared-config: mark ci-orchestrator as a custom Dependabot config

### DIFF
--- a/.github/actions/sync/shared-config.rb
+++ b/.github/actions/sync/shared-config.rb
@@ -47,6 +47,7 @@ custom_rubocop_repos = %w[
 ].freeze
 custom_dependabot_repos = %w[
   brew
+  ci-orchestrator
 ].freeze
 
 puts "Detecting changes…"


### PR DESCRIPTION
We want to use grouped updates here