### PR TITLE
sync-shared-config: sync private repos.

### DIFF
--- a/.github/actions/sync/shared-config.rb
+++ b/.github/actions/sync/shared-config.rb
@@ -40,13 +40,18 @@ homebrew_rubocop_config = homebrew_rubocop_config_yaml.reject do |key, _|
   key.match?(%r{\Arequire|inherit_from|inherit_mode|Cask/|Formula|Homebrew|Performance/|RSpec|Sorbet/})
 end.to_yaml
 
+custom_ruby_version_repos = %w[
+  mass-bottling-tracker-private
+].freeze
 custom_rubocop_repos = %w[
   ci-orchestrator
+  mass-bottling-tracker-private
   orka_api_client
   ruby-macho
 ].freeze
 custom_dependabot_repos = %w[
   brew
+  brew-pip-audit
   ci-orchestrator
 ].freeze
 
@@ -63,6 +68,8 @@ puts "Detecting changes…"
 
   case file
   when ruby_version
+    next if custom_ruby_version_repos.include?(repository_name)
+
     target_path.write("#{homebrew_ruby_version}\n")
   when rubocop_yml
     next if custom_rubocop_repos.include?(repository_name)

--- a/.github/workflows/sync-shared-config.yml
+++ b/.github/workflows/sync-shared-config.yml
@@ -44,6 +44,10 @@ jobs:
           - Homebrew/orka_api_client
           - Homebrew/ruby-macho
           - Homebrew/rubydoc.brew.sh
+          - Homebrew/mass-bottling-tracker-private
+          - Homebrew/governance-private
+          - Homebrew/security-private
+          - Homebrew/ops-private
       fail-fast: false
     steps:
       - name: Set up Homebrew
@@ -70,6 +74,7 @@ jobs:
         with:
           repository: ${{ matrix.repo }}
           path: vendor/${{ matrix.repo }}
+          token: ${{ secrets.HOMEBREW_DOTGITHUB_WORKFLOW_TOKEN }}
           persist-credentials: false
 
       - name: Configure Git user


### PR DESCRIPTION
- This requires using a token.
- This may well not work until the token is adjusted.
- This PR (👋🏻) discloses this repo names but they are not sensitive.