### PR TITLE
workflows/sync-shared-config: run on a schedule.

### DIFF
--- a/.github/workflows/sync-shared-config.yml
+++ b/.github/workflows/sync-shared-config.yml
@@ -5,12 +5,14 @@ on:
     branches:
       - master
   pull_request:
+  schedule:
+    - cron: "0 */3 * * *" # Every 3 hours
 
 permissions:
   contents: read
 
 concurrency:
-  group: sync-shared-config
+  group: "sync-shared-config-${{ github.ref }}"
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
Run every 3 hours and allow concurrent runs of pushed branches.