### PR TITLE
sync/shared-config: move brew's ruby version to Library/Homebrew.

### DIFF
--- a/.github/actions/sync/shared-config.rb
+++ b/.github/actions/sync/shared-config.rb
@@ -70,6 +70,8 @@ puts "Detecting changes…"
   when ruby_version
     next if custom_ruby_version_repos.include?(repository_name)
 
+    target_path = target_directory_path/"Library/Homebrew/#{ruby_version}" if repository_name == "brew"
+
     target_path.write("#{homebrew_ruby_version}\n")
   when rubocop_yml
     next if custom_rubocop_repos.include?(repository_name)


### PR DESCRIPTION
This will avoid issues with `#!/usr/bin/env ruby` shebangs in Homebrew's prefix.

See also https://github.com/Homebrew/brew/pull/17441