### PR TITLE
sync/shared-config: sync docs, improve dependabot.

### DIFF
--- a/.github/workflows/sync-shared-config.yml
+++ b/.github/workflows/sync-shared-config.yml
@@ -16,7 +16,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  sync-shared-config:
+  sync:
     if: github.repository == 'Homebrew/.github'
     runs-on: ubuntu-latest
     strategy:
@@ -112,3 +112,9 @@ jobs:
             This pull request was created automatically by the
             [`sync-shared-config`](https://github.com/Homebrew/.github/blob/HEAD/.github/workflows/sync-shared-config.yml)
             workflow.
+  conclusion:
+    needs: sync
+    runs-on: ubuntu-latest
+    steps:
+      - name: Conclusion
+        run: echo "Sync shared configurations completed"


### PR DESCRIPTION
- the docs syncing should allow us to enforce a consistent structure for documentation across all our repositories.
- the dependabot syncing changes should avoid red CI and unnecessary dependabot checks in repositories missing the relevant files.

While we're here:
- use `yaml` consistently instead of `yml`