### PR TITLE
Fix dependabot.yml handling

### DIFF
--- a/.github/actions/sync/shared-config.rb
+++ b/.github/actions/sync/shared-config.rb
@@ -73,6 +73,7 @@ custom_rubocop_repos = %w[
   ruby-macho
 ].freeze
 custom_dependabot_repos = %w[
+  .github
   brew
   ci-orchestrator
 ].freeze

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,18 +1,55 @@
-# This file is synced from the `.github` repository, do not modify it directly.
----
+# This file is used as a base for all other repositories in the Homebrew GitHub
+# organisation so intentionally contains package-ecosystems that do not apply to
+# this repository.
 version: 2
-updates:
-- package-ecosystem: github-actions
-  directory: "/"
-  schedule:
-    interval: daily
-  allow:
-  - dependency-type: all
-  ignore:
-  - dependency-name: actions/stale
-  - dependency-name: dessant/lock-threads
-  groups:
-    artifacts:
-      patterns:
-      - actions/*-artifact
 
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: daily
+    allow:
+      - dependency-type: all
+    # The actions in triage-issues.yml are updated in the Homebrew/.github repo
+    ignore:
+      - dependency-name: actions/stale
+      - dependency-name: dessant/lock-threads
+    groups:
+      artifacts:
+        patterns:
+          - actions/*-artifact
+
+  - package-ecosystem: bundler
+    directory: /
+    schedule:
+      interval: daily
+    allow:
+      - dependency-type: all
+
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: daily
+    allow:
+      - dependency-type: all
+
+  - package-ecosystem: docker
+    directory: /
+    schedule:
+      interval: daily
+    allow:
+      - dependency-type: all
+
+  - package-ecosystem: devcontainers
+    directory: /
+    schedule:
+      interval: daily
+    allow:
+      - dependency-type: all
+
+  - package-ecosystem: pip
+    directory: /
+    schedule:
+      interval: daily
+    allow:
+      - dependency-type: all


### PR DESCRIPTION
Need to ensure that this repository contains the superset of all required values for all other repositories in the Homebrew GitHub organisation so that filtering works as expected.