### PR TITLE
sync-shared-config: fix style and style checks.

### DIFF
--- a/.github/actions/sync/shared-config.rb
+++ b/.github/actions/sync/shared-config.rb
@@ -175,12 +175,16 @@ puts "Detecting changes…"
 end
 
 # Update Gemfile.lock if it exists, based on the Ruby version.
+#
+# rubocop:disable Homebrew/NegateInclude
+# We don't have Homebrew exclude? method here.
 if !custom_ruby_version_repos.include?(repository_name) && (target_directory_path/"Gemfile.lock").exist?
   Dir.chdir target_directory_path do
     puts "Running bundle install..."
     system "bundle update --ruby --bundler --quiet >/dev/null"
   end
 end
+# rubocop:enable Homebrew/NegateInclude
 
 out, err, status = Open3.capture3("git", "-C", target_directory, "status", "--porcelain", "--ignore-submodules=dirty")
 raise err unless status.success?

--- a/.github/workflows/sync-shared-config.yml
+++ b/.github/workflows/sync-shared-config.yml
@@ -115,6 +115,7 @@ jobs:
   conclusion:
     needs: sync
     runs-on: ubuntu-latest
+    if: always()
     steps:
-      - name: Conclusion
-        run: echo "Sync shared configurations completed"
+      - name: Result
+        run: ${{ needs.sync.result == 'success' }}


### PR DESCRIPTION
- Use `exclude?` instead of `include?` to make RuboCop happy
- Properly check the `sync` jobs success so that auto-merge is not run if jobs are failing