### PR TITLE
Pre-sync initial Ruby version

### DIFF
--- a/.github/workflows/sync-shared-config.yml
+++ b/.github/workflows/sync-shared-config.yml
@@ -88,6 +88,9 @@ jobs:
         uses: Homebrew/actions/setup-commit-signing@master
         with:
           signing_key: ${{ secrets.BREWTESTBOT_GPG_SIGNING_SUBKEY }}
+      
+      - name: Sync initial Ruby version
+        run: cp /home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/.ruby-version .
 
       - name: Install Ruby
         uses: ruby/setup-ruby@v1


### PR DESCRIPTION
Currently, the `bundle update --ruby` is incorrectly synced on Homebrew/.github's `.ruby-version` rather than Homebrew/brew's.

This is because the flow goes like this:
* .ruby-version on .github is 3.3.2
* setup-ruby installs 3.3.2
* sync script run under 3.3.2
* 3.3.3 copied from Homebrew/brew to repo
* bundler install --ruby called but the ruby installed is still 3.3.2 as we didn't run setup-ruby again
* update to lockfile doesn't happen (until after the .ruby-version update PR is merged in Homebrew/.github)

This fixes it by doing an initial pre-sync of the ruby version _prior_ to starting the sync script. Bundler will then operate under that new Ruby.