### PR TITLE
workflows/sync-shared-config: fix `git` command.

### DIFF
--- a/.github/workflows/sync-shared-config.yml
+++ b/.github/workflows/sync-shared-config.yml
@@ -109,7 +109,7 @@ jobs:
           set -euo pipefail
 
           cd target/${{ matrix.repo }}
-          git b sync-shared-config
+          git checkout -b sync-shared-config
           git commit -am "Synchronize shared configuration" -m "This pull request was created automatically by the  [`sync-shared-config`](https://github.com/Homebrew/.github/blob/HEAD/.github/workflows/sync-shared-config.yml) workflow."
           gh pr create
         env:


### PR DESCRIPTION
Need to use the full version, not my local alias 🤦🏻 