### PR TITLE
workflows/sync-shared-config: no `git commit` needed.

### DIFF
--- a/.github/workflows/sync-shared-config.yml
+++ b/.github/workflows/sync-shared-config.yml
@@ -110,8 +110,8 @@ jobs:
 
           cd target/${{ matrix.repo }}
           git checkout -b sync-shared-config
-          git commit -am "Synchronize shared configuration" -m 'This pull request was created automatically by the [`sync-shared-config`](https://github.com/Homebrew/.github/blob/HEAD/.github/workflows/sync-shared-config.yml) workflow.'
-          gh pr create
+          gh pr create --title "Synchronize shared configuration" --body
+          'This pull request was created automatically by the `sync-shared-config` workflow.'
         env:
           GITHUB_TOKEN: ${{ secrets.HOMEBREW_DOTGITHUB_WORKFLOW_TOKEN }}
   conclusion:


### PR DESCRIPTION
This is done already by `shared-config.rb`.