### PR TITLE
workflows/sync-shared-config: fix `--body` argument to `gh pr create`.

### DIFF
--- a/.github/workflows/sync-shared-config.yml
+++ b/.github/workflows/sync-shared-config.yml
@@ -110,8 +110,8 @@ jobs:
 
           cd target/${{ matrix.repo }}
           git checkout -b sync-shared-config
-          gh pr create --title "Synchronize shared configuration" --body
-          'This pull request was created automatically by the `sync-shared-config` workflow.'
+          gh pr create --title "Synchronize shared configuration" --body \
+            'This pull request was created automatically by the [`sync-shared-config`](https://github.com/Homebrew/.github/blob/HEAD/.github/actions/sync/shared-config.rb) workflow.'
         env:
           GITHUB_TOKEN: ${{ secrets.HOMEBREW_DOTGITHUB_WORKFLOW_TOKEN }}
   conclusion:


### PR DESCRIPTION
Also, while we're here, add a nicer link to the workflow.