### PR TITLE
workflows/sync-shared-config: use `--head` to specify the PR branch.

### DIFF
--- a/.github/workflows/sync-shared-config.yml
+++ b/.github/workflows/sync-shared-config.yml
@@ -110,7 +110,7 @@ jobs:
 
           cd target/${{ matrix.repo }}
           git checkout -b sync-shared-config
-          gh pr create --title "Synchronize shared configuration" --body 'This pull request was created automatically by the [`sync-shared-config`](https://github.com/Homebrew/.github/blob/HEAD/.github/actions/sync/shared-config.rb) workflow.'
+          gh pr create --head sync-shared-config --title "Synchronize shared configuration" --body 'This pull request was created automatically by the [`sync-shared-config`](https://github.com/Homebrew/.github/blob/HEAD/.github/actions/sync/shared-config.rb) workflow.'
         env:
           GITHUB_TOKEN: ${{ secrets.HOMEBREW_DOTGITHUB_WORKFLOW_TOKEN }}
   conclusion:


### PR DESCRIPTION
This should fix another error.