### PR TITLE
workflows/sync-shared-config: only create PR if needed.

### DIFF
--- a/.github/workflows/sync-shared-config.yml
+++ b/.github/workflows/sync-shared-config.yml
@@ -110,7 +110,11 @@ jobs:
 
           cd target/${{ matrix.repo }}
           git checkout -b sync-shared-config
-          gh pr create --head sync-shared-config --title "Synchronize shared configuration" --body 'This pull request was created automatically by the [`sync-shared-config`](https://github.com/Homebrew/.github/blob/HEAD/.github/actions/sync/shared-config.rb) workflow.'
+
+          if !gh pr view sync-shared-config
+          then
+            gh pr create --head sync-shared-config --title "Synchronize shared configuration" --body 'This pull request was created automatically by the [`sync-shared-config`](https://github.com/Homebrew/.github/blob/HEAD/.github/actions/sync/shared-config.rb) workflow.'
+          fi
         env:
           GITHUB_TOKEN: ${{ secrets.HOMEBREW_DOTGITHUB_WORKFLOW_TOKEN }}
   conclusion:


### PR DESCRIPTION
One may already be open.