### PR TITLE
sync/shared-config: remove locked threads file correctly.

### DIFF
--- a/.github/actions/sync/shared-config.rb
+++ b/.github/actions/sync/shared-config.rb
@@ -183,7 +183,7 @@ puts "Detecting changes…"
       "#{dependabot_config}\n",
     )
   when deprecated_lock_threads
-    FileUtils.rm_f target_path
+    FileUtils.rm_f path
   else
     next if path == target_path.to_s
 


### PR DESCRIPTION
Needed to remove the destination not target path here.