### PR TITLE
workflows/sync-shared-config: fix check for open PR

### DIFF
--- a/.github/workflows/sync-shared-config.yml
+++ b/.github/workflows/sync-shared-config.yml
@@ -111,11 +111,21 @@ jobs:
           cd target/${{ matrix.repo }}
           git checkout -b sync-shared-config
 
-          if ! gh pr view sync-shared-config
+          if gh api \
+              -X GET \
+              --header 'Accept: application/vnd.github+json' \
+              --header 'X-GitHub-Api-Version: 2022-11-28' \
+              /repos/{owner}/{repo}/pulls \
+              -f head=Homebrew:sync-shared-config \
+              -f state=open |
+              jq --exit-status any
           then
+            git push --force-with-lease origin sync-shared-config
+          else
             gh pr create --head sync-shared-config --title "Synchronize shared configuration" --body 'This pull request was created automatically by the [`sync-shared-config`](https://github.com/Homebrew/.github/blob/HEAD/.github/actions/sync/shared-config.rb) workflow.'
           fi
         env:
+          GH_REPO: ${{ matrix.repo }}
           GH_TOKEN: ${{ secrets.HOMEBREW_DOTGITHUB_WORKFLOW_TOKEN }}
   conclusion:
     needs: sync


### PR DESCRIPTION
`gh pr view` does not work well when there are multiple PRs associated with the same branch. Let's rely on the API instead.