### PR TITLE
workflows/sync-shared-config: fix PR creation (again)

### DIFF
--- a/.github/workflows/sync-shared-config.yml
+++ b/.github/workflows/sync-shared-config.yml
@@ -77,7 +77,6 @@ jobs:
           repository: ${{ matrix.repo }}
           path: target/${{ matrix.repo }}
           token: ${{ secrets.HOMEBREW_DOTGITHUB_WORKFLOW_TOKEN }}
-          persist-credentials: false
 
       - name: Configure Git user
         uses: Homebrew/actions/git-user-config@master


### PR DESCRIPTION
Since we push to the target repo, the credentials need to be persistent.