### PR TITLE
workflows/sync-shared-config: force push to branch (without lease)

### DIFF
--- a/.github/workflows/sync-shared-config.yml
+++ b/.github/workflows/sync-shared-config.yml
@@ -109,7 +109,7 @@ jobs:
 
           cd target/${{ matrix.repo }}
           git checkout -b sync-shared-config
-          git push --set-upstream --force-with-lease origin sync-shared-config
+          git push --set-upstream --force origin sync-shared-config
 
           if gh api \
               -X GET \


### PR DESCRIPTION
When we update a branch, force push with lease fails. While we can do a `git fetch`, there's no harm to just force push.