### PR TITLE
workflows/stale-issues: fix branch deletion

### DIFF
--- a/.github/workflows/stale-issues.yml
+++ b/.github/workflows/stale-issues.yml
@@ -13,6 +13,7 @@ on:
   issue_comment:
 
 permissions:
+  contents: write
   issues: write
   pull-requests: write
 


### PR DESCRIPTION
The `contents` permission needs to be set to `write` [^1].

Fixes https://github.com/Homebrew/homebrew-core/actions/runs/10311349943/job/28544771394#step:2:722.

[^1]: https://docs.github.com/en/rest/git/refs?apiVersion=2022-11-28#delete-a-reference
