### PR TITLE
sync/shared-config: Mark `governance-private` as a custom RuboCop repo

### DIFF
--- a/.github/actions/sync/shared-config.rb
+++ b/.github/actions/sync/shared-config.rb
@@ -78,6 +78,7 @@ custom_rubocop_repos = %w[
   mass-bottling-tracker-private
   orka_api_client
   ruby-macho
+  governance-private
 ].freeze
 custom_dependabot_repos = %w[
   .github


### PR DESCRIPTION
- There's a single script in here that's used once a year, we don't need all of the RuboCop rules and it was causing a lot of weirdness with the Sorbet cops.