### PR TITLE
actions/sync/shared-config: exclude vendor from docs RuboCop.

### DIFF
--- a/.github/actions/sync/shared-config.rb
+++ b/.github/actions/sync/shared-config.rb
@@ -51,6 +51,7 @@ homebrew_docs_rubocop_config_yaml = YAML.load_file(
   homebrew_repository_path/"docs/#{rubocop_yaml}",
   permitted_classes: [Symbol, Regexp],
 )
+homebrew_docs_rubocop_config_yaml["AllCops"]["Exclude"] << '"vendor/**/*"'
 homebrew_docs_rubocop_config = homebrew_docs_rubocop_config_yaml.reject do |key, _|
   key.match?(%r{\AFormulaAudit/|Sorbet/})
 end.to_yaml


### PR DESCRIPTION
This will avoid trying to check gems in the vendor directory.