### PR TITLE
actions/sync/shared-config: fix vendor exclude.

### DIFF
--- a/.github/actions/sync/shared-config.rb
+++ b/.github/actions/sync/shared-config.rb
@@ -44,6 +44,7 @@ homebrew_rubocop_config_yaml = YAML.load_file(
   homebrew_repository_path/"Library/#{rubocop_yaml}",
   permitted_classes: [Symbol, Regexp],
 )
+homebrew_rubocop_config_yaml["AllCops"]["Exclude"] << '"vendor/**/*"'
 homebrew_rubocop_config = homebrew_rubocop_config_yaml.reject do |key, _|
   key.match?(%r{\Arequire|inherit_from|inherit_mode|Cask/|Formula|Homebrew|Performance/|RSpec|Sorbet/})
 end.to_yaml
@@ -51,7 +52,6 @@ homebrew_docs_rubocop_config_yaml = YAML.load_file(
   homebrew_repository_path/"docs/#{rubocop_yaml}",
   permitted_classes: [Symbol, Regexp],
 )
-homebrew_docs_rubocop_config_yaml["AllCops"]["Exclude"] << '"vendor/**/*"'
 homebrew_docs_rubocop_config = homebrew_docs_rubocop_config_yaml.reject do |key, _|
   key.match?(%r{\AFormulaAudit/|Sorbet/})
 end.to_yaml


### PR DESCRIPTION
This should be in the general rubocop, not the docs one.