### PR TITLE
actions/sync/shared-config: use a wider vendor wildcard.

### DIFF
--- a/.github/actions/sync/shared-config.rb
+++ b/.github/actions/sync/shared-config.rb
@@ -44,7 +44,7 @@ homebrew_rubocop_config_yaml = YAML.load_file(
   homebrew_repository_path/"Library/#{rubocop_yaml}",
   permitted_classes: [Symbol, Regexp],
 )
-homebrew_rubocop_config_yaml["AllCops"]["Exclude"] << "vendor/**/*"
+homebrew_rubocop_config_yaml["AllCops"]["Exclude"] << "**/vendor/**/*"
 homebrew_rubocop_config = homebrew_rubocop_config_yaml.reject do |key, _|
   key.match?(%r{\Arequire|inherit_from|inherit_mode|Cask/|Formula|Homebrew|Performance/|RSpec|Sorbet/})
 end.to_yaml


### PR DESCRIPTION
Oh please just let this work properly already.