### PR TITLE
workflows/actionlint: run on push to `master` too

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - main
+      - master
     paths:
       - '.github/workflows/*.ya?ml'
   pull_request:


### PR DESCRIPTION
Most of our repos still use a `master` branch as default.
