### PR TITLE
workflows/actionlint: fix actionlint error

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -67,7 +67,7 @@ jobs:
     if: >
       always() &&
       !contains(fromJSON('[["cancelled", "skipped"]]'), needs.workflow_syntax.result) &&
-      !github.repository.private
+      !github.event.repository.private
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
It should be `github.event.repository.private`, not
`github.repository.private`.
