### PR TITLE
workflows/actionlint: avoid persisting credentials

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -31,6 +31,8 @@ jobs:
   workflow_syntax:
     if: github.repository_owner == 'Homebrew'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Set up Homebrew
         id: setup-homebrew
@@ -45,7 +47,7 @@ jobs:
 
       - uses: actions/checkout@v4
         with:
-          persist-credentials: ${{ github.event.repository.private }}
+          persist-credentials: false
 
       - run: zizmor --format sarif . >results.sarif
 


### PR DESCRIPTION
We don't need this on private repositories, apparently.
