### PR TITLE
actionlint: run on every push

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -6,11 +6,7 @@ on:
     branches:
       - main
       - master
-    paths:
-      - '.github/workflows/*.ya?ml'
   pull_request:
-    paths:
-      - '.github/workflows/*.ya?ml'
 
 defaults:
   run:


### PR DESCRIPTION
We currently run only when when workflow files are modified, but that
means we cannot make the results of the Zizmor scan a required status
check.

Let's just run this all the time so that we can make sure to never merge
regressions.

This will affect only one high-volume repo: Homebrew/cask. We can carve
out an exception for that if we need to. (Though I'm currently inclined
to do something similar on our high-volume repos anyway.)

See discussion at Homebrew/ci-orchestrator#255
