### PR TITLE
 sync-shared-config.yml: explicit persistence of credentials

### DIFF
--- a/.github/workflows/sync-shared-config.yml
+++ b/.github/workflows/sync-shared-config.yml
@@ -82,6 +82,8 @@ jobs:
           repository: ${{ matrix.repo }}
           path: target/${{ matrix.repo }}
           token: ${{ secrets.HOMEBREW_DOTGITHUB_WORKFLOW_TOKEN }}
+          # Intentioanlly persisted to allow `git push` below.
+          persist-credentials: true
 
       - name: Configure Git user
         uses: Homebrew/actions/git-user-config@master


### PR DESCRIPTION
This has the same effect as #214, but in the opposite direction: it suppresses the error by making it clear that we're intending to persist credentials.