### PR TITLE
actionlint: stop suppressing `zizmor` exit code

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -45,9 +45,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - run: |
-          # NOTE: exit code intentionally suppressed here
-          zizmor --format sarif . > results.sarif || true
+      - run: zizmor --format sarif . > results.sarif
 
       - name: Upload SARIF file
         uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4


### PR DESCRIPTION
`zizmor` no longer exits with an error when passed `--format sarif`.
