### PR TITLE
workflows/sync-shared-config: run weekly.

### DIFF
--- a/.github/workflows/sync-shared-config.yml
+++ b/.github/workflows/sync-shared-config.yml
@@ -6,7 +6,7 @@ on:
       - master
   pull_request:
   schedule:
-    - cron: "0 */3 * * *" # Every 3 hours
+    - cron: "0 8 * * 1" # Every Monday at 8 AM
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
We're getting so many of these PRs now and we don't need this much syncing/noise when we can do it less often or manually with a `workflow_dispatch` if needed.