### PR TITLE
workflows/actionlint: enable merge queue/group jobs.

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -7,6 +7,7 @@ on:
       - main
       - master
   pull_request:
+  merge_group:
 
 defaults:
   run:


### PR DESCRIPTION
This should allow us to make use of the GitHub merge queue to ensure that we're not merging outdated code (or breaking `master`) but avoiding the need to continually merge into/rebase PR branches.

This should be safe to merge as-is as is essentially a no-op without the merge queue enabled.