### PR TITLE
build(deps): bump ruby/setup-ruby from 1.202.0 to 1.203.0

### DIFF
--- a/.github/workflows/sync-shared-config.yml
+++ b/.github/workflows/sync-shared-config.yml
@@ -99,7 +99,7 @@ jobs:
         run: cp /home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/.ruby-version .
 
       - name: Install Ruby
-        uses: ruby/setup-ruby@a2bbe5b1b236842c1cb7dd11e8e3b51e0a616acc # v1.202.0
+        uses: ruby/setup-ruby@2a18b06812b0e15bb916e1df298d3e740422c47e # v1.203.0
         with:
           bundler-cache: true
 


### PR DESCRIPTION
https://github.com/Homebrew/.github/pull/221 from a non-fork.