### PR TITLE
build(deps): bump ruby/setup-ruby from 1.203.0 to 1.204.0

### DIFF
--- a/.github/workflows/sync-shared-config.yml
+++ b/.github/workflows/sync-shared-config.yml
@@ -99,7 +99,7 @@ jobs:
         run: cp /home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/.ruby-version .
 
       - name: Install Ruby
-        uses: ruby/setup-ruby@2a18b06812b0e15bb916e1df298d3e740422c47e # v1.203.0
+        uses: ruby/setup-ruby@401c19e14f474b54450cd3905bb8b86e2c8509cf # v1.204.0
         with:
           bundler-cache: true
 


### PR DESCRIPTION
https://github.com/Homebrew/.github/pull/228 from a non-fork.