### PR TITLE
Update dependabot actions and scheduled files weekly.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,7 @@ updates:
   - package-ecosystem: github-actions
     directory: /
     schedule:
-      interval: daily
+      interval: weekly
     allow:
       - dependency-type: all
     # The actions in triage-issues.yml are updated in the Homebrew/.github repo

--- a/.github/workflows/sync-shared-config.yml
+++ b/.github/workflows/sync-shared-config.yml
@@ -111,7 +111,7 @@ jobs:
         run: ./.github/actions/sync/shared-config.rb "${TARGET}" '/home/linuxbrew/.linuxbrew/Homebrew'
 
       - name: Create pull request
-        if: github.ref == 'refs/heads/master' && steps.detect_changes.outputs.pull_request == 'true'
+        if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
         run: |
           cd "target/$GH_REPO"
           git checkout -b sync-shared-config


### PR DESCRIPTION
This should reduce the amount of PR spam we get.

If there's critical vulnerabilities: they will be updated more often or can be done manually with a workflow dispatch.