### PR TITLE
build(deps): bump ruby/setup-ruby from 1.207.0 to 1.208.0

### DIFF
--- a/.github/workflows/sync-shared-config.yml
+++ b/.github/workflows/sync-shared-config.yml
@@ -99,7 +99,7 @@ jobs:
         run: cp /home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/.ruby-version .
 
       - name: Install Ruby
-        uses: ruby/setup-ruby@4a9ddd6f338a97768b8006bf671dfbad383215f4 # v1.207.0
+        uses: ruby/setup-ruby@868b3f088412f139260f27f5b148179b9dd6b008 # v1.208.0
         with:
           bundler-cache: true
 


### PR DESCRIPTION
https://github.com/Homebrew/.github/pull/243 from a non-fork.