### PR TITLE
actionlint: bump upload-sarif to v3.28.5

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -79,7 +79,7 @@ jobs:
           path: results.sarif
 
       - name: Upload SARIF file
-        uses: github/codeql-action/upload-sarif@b6a472f63d85b9c78a3ac5e89422239fc15e9b3c # v3.28.1
+        uses: github/codeql-action/upload-sarif@f6091c0113d1dcf9b98e269ee48e8a7e51b7bdd4 # v3.28.5
         with:
           sarif_file: results.sarif
           category: zizmor


### PR DESCRIPTION
This addresses https://github.com/advisories/GHSA-vqf5-2xx6-9wfm.

That vulnerability has no direct impact on us since we're not doing Java/Kotlin scanning, but there's also no reason to keep it on our radar.

Detected with `zizmor`:

```
error[known-vulnerable-actions]: action has a known vulnerability
  --> .github/workflows/actionlint.yml:82:9
   |
82 |         uses: github/codeql-action/upload-sarif@b6a472f63d85b9c78a3ac5e89422239fc15e9b3c # v3.28.1
   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ GHSA-vqf5-2xx6-9wfm
   |
   = note: audit confidence → High
```