### PR TITLE
Improve sync schedules

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,8 @@ updates:
     directory: /
     schedule:
       interval: weekly
+      # every Monday at 8AM
+      cron: "0 8 * * 1"
     allow:
       - dependency-type: all
     # The actions in triage-issues.yml are updated in the Homebrew/.github repo
@@ -21,34 +23,44 @@ updates:
   - package-ecosystem: bundler
     directory: /
     schedule:
-      interval: daily
+      interval: weekly
+      # every Monday at 8AM
+      cron: "0 8 * * 1"
     allow:
       - dependency-type: all
 
   - package-ecosystem: npm
     directory: /
     schedule:
-      interval: daily
+      interval: weekly
+      # every Monday at 8AM
+      cron: "0 8 * * 1"
     allow:
       - dependency-type: all
 
   - package-ecosystem: docker
     directory: /
     schedule:
-      interval: daily
+      interval: weekly
+      # every Monday at 8AM
+      cron: "0 8 * * 1"
     allow:
       - dependency-type: all
 
   - package-ecosystem: devcontainers
     directory: /
     schedule:
-      interval: daily
+      interval: weekly
+      # every Monday at 8AM
+      cron: "0 8 * * 1"
     allow:
       - dependency-type: all
 
   - package-ecosystem: pip
     directory: /
     schedule:
-      interval: daily
+      interval: weekly
+      # every Monday at 8AM
+      cron: "0 8 * * 1"
     allow:
       - dependency-type: all

--- a/.github/workflows/sync-shared-config.yml
+++ b/.github/workflows/sync-shared-config.yml
@@ -6,7 +6,7 @@ on:
       - master
   pull_request:
   schedule:
-    - cron: "0 8 * * 1" # Every Monday at 8 AM
+    - cron: "0 8 * * 4" # Every Thursday at 8 AM
   workflow_dispatch:
 
 permissions:
@@ -37,24 +37,17 @@ jobs:
           - Homebrew/formula-patches
           - Homebrew/formulae.brew.sh
           - Homebrew/glibc-bootstrap
-          - Homebrew/homebrew-aliases
-          - Homebrew/homebrew-bundle
           - Homebrew/homebrew-cask
           - Homebrew/homebrew-command-not-found
           - Homebrew/homebrew-core
-          - Homebrew/homebrew-formula-analytics
-          - Homebrew/homebrew-linux-fonts
           - Homebrew/homebrew-portable-ruby
-          - Homebrew/homebrew-services
           - Homebrew/homebrew-test-bot
           - Homebrew/install
           - Homebrew/orka_api_client
           - Homebrew/ruby-macho
           - Homebrew/rubydoc.brew.sh
           - Homebrew/mass-bottling-tracker-private
-          - Homebrew/governance-private
-          - Homebrew/security-private
-          - Homebrew/ops-private
+          - Homebrew/private
       fail-fast: false
     steps:
       - name: Set up Homebrew


### PR DESCRIPTION
- Update Dependabot once a week on Monday at 8AM (for new releases)
- Update sync-shared-config once a week on Thursday at 8AM (for after Dependabot has hopefully been mostly merged/updated)
- Update repository list based on the latest, non-deprecated repositories