### PR TITLE
workflows: remove no-op ssh signing value

### DIFF
--- a/.github/workflows/sync-shared-config.yml
+++ b/.github/workflows/sync-shared-config.yml
@@ -86,7 +86,6 @@ jobs:
       - name: Set up SSH commit signing
         uses: Homebrew/actions/setup-commit-signing@master
         with:
-          ssh: true
           signing_key: ${{ secrets.BREWTESTBOT_SSH_SIGNING_KEY }}
 
       - name: Sync initial Ruby version


### PR DESCRIPTION
Now that we've removed all the GPG code, this is a no-op.