### PR TITLE
workflows/actionlint: don't trigger on merge_group

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -7,7 +7,6 @@ on:
       - main
       - master
   pull_request:
-  merge_group:
 
 defaults:
   run:
@@ -50,6 +49,8 @@ jobs:
 
       - name: Upload SARIF file
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        # We can't use the SARIF file when triggered by `merge_group` so we don't upload it.
+        if: always() && github.event_name != 'merge_group'
         with:
           name: results.sarif
           path: results.sarif
@@ -66,7 +67,8 @@ jobs:
     if: >
       always() &&
       !contains(fromJSON('["cancelled", "skipped"]'), needs.workflow_syntax.result) &&
-      !github.event.repository.private
+      !github.event.repository.private &&
+      github.event_name != 'merge_group'
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
From what I can see we aren't able to upload the SARIF record within the merge group because it can't find a ref to upload against.

This was seen in `homebrew/cask` - https://github.com/Homebrew/homebrew-cask/actions/runs/14210386041/job/39816439146

As far as I can see, no other repositories that this file is synced to have merge queue enabled, so the failure hasn't been seen until now.

To turn on the merge queue for `homebrew/cask` this trigger was disabled, but it's being brought back with the sync job in https://github.com/Homebrew/homebrew-cask/pull/207413

---

An alternative may be to skip the upload job, and only run the `actionlint` side of the workflow when it is a merge_group, unless there is an alternative way to link to a ref.

---

CC: @MikeMcQuaid because you turned it on in https://github.com/Homebrew/.github/pull/220 and may have a better understanding here.