### PR TITLE
Fix various syncing errors

### DIFF
--- a/.github/actions/sync/shared-config.rb
+++ b/.github/actions/sync/shared-config.rb
@@ -86,7 +86,6 @@ custom_ruby_version_repos = %w[
 custom_rubocop_repos = %w[
   ci-orchestrator
   mass-bottling-tracker-private
-  orka_api_client
   ruby-macho
 ].freeze
 custom_dependabot_repos = %w[

--- a/.github/actions/sync/shared-config.rb
+++ b/.github/actions/sync/shared-config.rb
@@ -47,7 +47,7 @@ homebrew_rubocop_config_yaml = YAML.load_file(
 )
 homebrew_rubocop_config_yaml["AllCops"]["Exclude"] << "**/vendor/**/*"
 homebrew_rubocop_config = homebrew_rubocop_config_yaml.reject do |key, _|
-  key.match?(%r{\Arequire|inherit_from|inherit_mode|Cask/|Formula|Homebrew|Performance/|RSpec|Sorbet/})
+  key.match?(%r{\Arequire|plugins|inherit_from|inherit_mode|Cask/|Formula|Homebrew|Performance/|RSpec|Sorbet/})
 end.to_yaml
 homebrew_docs_rubocop_config_yaml = YAML.load_file(
   homebrew_repository_path/"docs/#{rubocop_yaml}",

--- a/.github/workflows/sync-shared-config.yml
+++ b/.github/workflows/sync-shared-config.yml
@@ -21,32 +21,49 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  generate-matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.generate-matrix.outputs.matrix }}
+    steps:
+      - name: Generate matrix
+        id: generate-matrix
+        env:
+          SKIP_PRIVATE: ${{ github.event_name == 'pull_request' && github.actor == 'dependabot[bot]' }}
+        run: |
+          repositories=(
+            Homebrew/.github
+            Homebrew/actions
+            Homebrew/brew
+            Homebrew/brew-pip-audit
+            Homebrew/brew.sh
+            Homebrew/ci-orchestrator
+            Homebrew/discussions
+            Homebrew/formula-patches
+            Homebrew/formulae.brew.sh
+            Homebrew/glibc-bootstrap
+            Homebrew/homebrew-cask
+            Homebrew/homebrew-command-not-found
+            Homebrew/homebrew-core
+            Homebrew/homebrew-portable-ruby
+            Homebrew/homebrew-test-bot
+            Homebrew/install
+            Homebrew/ruby-macho
+            Homebrew/rubydoc.brew.sh
+            Homebrew/mass-bottling-tracker-private
+            Homebrew/private
+          )
+          if [[ "${SKIP_PRIVATE}" == true ]]; then
+            read -r -a repositories <<< "${repositories[@]//*private}"
+          fi
+          echo "matrix=$(jq -cn '$ARGS.positional' --args -- "${repositories[@]}")" >> "${GITHUB_OUTPUT}"
   sync:
     if: github.repository == 'Homebrew/.github'
+    needs: generate-matrix
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        repo:
-          - Homebrew/.github
-          - Homebrew/actions
-          - Homebrew/brew
-          - Homebrew/brew-pip-audit
-          - Homebrew/brew.sh
-          - Homebrew/ci-orchestrator
-          - Homebrew/discussions
-          - Homebrew/formula-patches
-          - Homebrew/formulae.brew.sh
-          - Homebrew/glibc-bootstrap
-          - Homebrew/homebrew-cask
-          - Homebrew/homebrew-command-not-found
-          - Homebrew/homebrew-core
-          - Homebrew/homebrew-portable-ruby
-          - Homebrew/homebrew-test-bot
-          - Homebrew/install
-          - Homebrew/ruby-macho
-          - Homebrew/rubydoc.brew.sh
-          - Homebrew/mass-bottling-tracker-private
-          - Homebrew/private
+        repo: ${{fromJson(needs.generate-matrix.outputs.matrix)}}
       fail-fast: false
     steps:
       - name: Set up Homebrew
@@ -73,7 +90,7 @@ jobs:
         with:
           repository: ${{ matrix.repo }}
           path: target/${{ matrix.repo }}
-          token: ${{ secrets.HOMEBREW_DOTGITHUB_WORKFLOW_TOKEN }}
+          token: ${{ secrets.HOMEBREW_DOTGITHUB_WORKFLOW_TOKEN || github.token }}
           # Intentioanlly persisted to allow `git push` below.
           persist-credentials: true
 

--- a/.github/workflows/sync-shared-config.yml
+++ b/.github/workflows/sync-shared-config.yml
@@ -102,7 +102,7 @@ jobs:
         run: ./.github/actions/sync/shared-config.rb "${TARGET}" '/home/linuxbrew/.linuxbrew/Homebrew'
 
       - name: Create pull request
-        if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+        if: (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && steps.detect_changes.outputs.pull_request == 'true'
         run: |
           cd "target/$GH_REPO"
           git checkout -b sync-shared-config

--- a/.github/workflows/sync-shared-config.yml
+++ b/.github/workflows/sync-shared-config.yml
@@ -43,7 +43,6 @@ jobs:
           - Homebrew/homebrew-portable-ruby
           - Homebrew/homebrew-test-bot
           - Homebrew/install
-          - Homebrew/orka_api_client
           - Homebrew/ruby-macho
           - Homebrew/rubydoc.brew.sh
           - Homebrew/mass-bottling-tracker-private


### PR DESCRIPTION
The scheduled run has been in bad health for some time: https://github.com/Homebrew/.github/actions/workflows/sync-shared-config.yml?query=event%3Aschedule

* Support Dependabot PRs better so we (hopefully) don't need to do manual work to merge them anymore.
  - Private repos aren't tested anymore in Dependabot PRs but that's probably fine - they'll still sync on schedule like the rest and the only thing about private repos that Dependabot could really break is `actions/checkout` token handling - but that would be a major bug on GitHub's side.
* Fix workflow erroring when no changes need to be made
* Handle RuboCop plugins properly (we previously stripped `require` but weren't stripping `plugins`)
* Remove `orka_api_client` handling, which I've deprecated