### PR TITLE
Configure zizmor to allow `Homebrew/actions/*` to point to `master`

### DIFF
--- a/.github/actions/sync/shared-config.rb
+++ b/.github/actions/sync/shared-config.rb
@@ -122,6 +122,7 @@ puts "Detecting changes…"
   deprecated_lock_threads,
   actionlint_workflow_yaml,
   ".github/workflows/stale-issues.yml",
+  ".github/zizmor.yml",
 ].each do |path|
   target_path = target_directory_path/path
   target_path.dirname.mkpath

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,5 @@
+rules:
+  unpinned-uses:
+    config:
+      policies:
+        Homebrew/actions/*: ref-pin


### PR DESCRIPTION
This is internally owned so we don't really gain much security benefits here.

Should fix some security alerts that popped up in the last couple days. I'll follow up with the CodeQL ones since for some reason they are substantially more complex to configure.