### PR TITLE
workflows/sync-shared-config: change sync to every Tuesday.

### DIFF
--- a/.github/workflows/sync-shared-config.yml
+++ b/.github/workflows/sync-shared-config.yml
@@ -6,7 +6,7 @@ on:
       - master
   pull_request:
   schedule:
-    - cron: "0 8 * * 4" # Every Thursday at 8 AM
+    - cron: "0 8 * * 2" # Every Tuesday at 8 AM
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
This follows on from the Homebrew/brew dependabot sync on Friday in https://github.com/Homebrew/brew/pull/19991