### PR TITLE
Revamp Dependabot configuration.

### DIFF
--- a/.github/actions/sync/shared-config.rb
+++ b/.github/actions/sync/shared-config.rb
@@ -90,8 +90,6 @@ custom_rubocop_repos = %w[
 ].freeze
 custom_dependabot_repos = %w[
   .github
-  brew
-  ci-orchestrator
 ].freeze
 custom_docs_repos = %w[
   brew

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,6 @@
 # This file is used as a base for all other repositories in the Homebrew GitHub
 # organisation so intentionally contains package-ecosystems that do not apply to
-# this repository.
+# this repository. They will be stripped out if unneeded by the sync action.
 version: 2
 
 updates:
@@ -8,59 +8,86 @@ updates:
     directory: /
     schedule:
       interval: weekly
-      day: monday
+      day: "friday"
       time: "08:00"
+      timezone: "Etc/UTC"
     allow:
       - dependency-type: all
-    # The actions in triage-issues.yml are updated in the Homebrew/.github repo
-    ignore:
-      - dependency-name: actions/stale
     groups:
-      artifacts:
+      github-actions:
         patterns:
-          - actions/*-artifact
+          - "*"
 
   - package-ecosystem: bundler
-    directory: /
+    directories:
+      - /
+      - /Library/Homebrew
     schedule:
       interval: weekly
-      day: monday
+      day: "friday"
       time: "08:00"
+      timezone: "Etc/UTC"
     allow:
       - dependency-type: all
+    groups:
+      bundler:
+        patterns:
+          - "*"
 
   - package-ecosystem: npm
     directory: /
     schedule:
       interval: weekly
-      day: monday
+      day: "friday"
       time: "08:00"
+      timezone: "Etc/UTC"
     allow:
       - dependency-type: all
+    groups:
+      npm:
+        patterns:
+          - "*"
 
   - package-ecosystem: docker
     directory: /
     schedule:
       interval: weekly
-      day: monday
+      day: "friday"
       time: "08:00"
+      timezone: "Etc/UTC"
     allow:
       - dependency-type: all
+    groups:
+      docker:
+        patterns:
+          - "*"
 
   - package-ecosystem: devcontainers
     directory: /
     schedule:
       interval: weekly
-      day: monday
+      day: "friday"
       time: "08:00"
+      timezone: "Etc/UTC"
     allow:
       - dependency-type: all
+    groups:
+      devcontainers:
+        patterns:
+          - "*"
 
   - package-ecosystem: pip
-    directory: /
+    directories:
+      - /
+      - /Library/Homebrew/formula-analytics/
     schedule:
       interval: weekly
-      day: monday
+      day: "friday"
       time: "08:00"
+      timezone: "Etc/UTC"
     allow:
       - dependency-type: all
+    groups:
+      pip:
+        patterns:
+          - "*"


### PR DESCRIPTION
After trying this out in Homebrew/brew, let's adopt a similar approach on all other repositories:

- make Homebrew/brew and Homebrew/ci-orchestrator consistent with this repository for now to try things out
- do updates weekly rather than daily. GitHub will still push out urgent security updates ad-hoc.
- do all updates on Friday at 08:00 UTC to allow syncing earlier in the week from this repository and then later in the week for dependabot
- use groups for all updates
- use directories to allow grouping updates by repository and handling more repositories with different layouts