### PR TITLE
Allow unpinned Homebrew actions in CodeQL

### DIFF
--- a/.github/actions/sync/shared-config.rb
+++ b/.github/actions/sync/shared-config.rb
@@ -130,6 +130,7 @@ puts "Detecting changes…"
   actionlint_workflow_yaml,
   ".github/workflows/stale-issues.yml",
   ".github/zizmor.yml",
+  ".github/codeql/extensions/homebrew-actions.yml",
 ].each do |path|
   target_path = target_directory_path/path
   target_path.dirname.mkpath

--- a/.github/codeql/extensions/homebrew-actions.yml
+++ b/.github/codeql/extensions/homebrew-actions.yml
@@ -1,0 +1,6 @@
+extensions:
+  - addsTo:
+      pack: codeql/actions-all
+      extensible: trustedActionsOwnerDataModel
+    data:
+      - ["Homebrew"]


### PR DESCRIPTION
Should fix the hundreds of alerts everywhere.

This aligns with how we have configured zizmor.