### PR TITLE
sync/shared-config: strip unnecessary YAML newline.

### DIFF
--- a/.github/actions/sync/shared-config.rb
+++ b/.github/actions/sync/shared-config.rb
@@ -202,6 +202,7 @@ puts "Detecting changes…"
       dependabot_config
     else
       Pathname(path).read
+                    .chomp
     end
 
     FileUtils.rm_f target_path


### PR DESCRIPTION
We're adding this now when not needed.