### PR TITLE
actionlint: set `GH_TOKEN` for `zizmor`

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -52,6 +52,8 @@ jobs:
           persist-credentials: false
 
       - run: zizmor --format sarif . > results.sarif
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload SARIF file
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2


### PR DESCRIPTION
This enables additional checks such as `impostor-commit`,
`ref-confusion`, `known-vulnerable-actions`, and others.
