### PR TITLE
actionlint: run `workflow_syntax` in a container

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -35,6 +35,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    container:
+      image: ghcr.io/homebrew/ubuntu22.04:main
     steps:
       - name: Set up Homebrew
         id: setup-homebrew


### PR DESCRIPTION
This will make this job run a bit faster. We didn't run it in a
container previously because it was erroring out for some reason in
Homebrew/core, but it seems to be fine now? See
Homebrew/homebrew-core#229566.
