### PR TITLE
actionlint: run on all PRs

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -11,8 +11,6 @@ on:
       - 'Formula/s/shellcheck.rb'
       - 'Formula/z/zizmor.rb'
   pull_request:
-    paths:
-      - '.github/workflows/*.ya?ml'
 
 defaults:
   run:


### PR DESCRIPTION
This is needed in order to merge Homebrew/ci-orchestrator#579.
