### PR TITLE
github/dependabot: fix cooldown syntax (again).

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,9 +18,9 @@ updates:
         patterns:
           - "*"
     cooldown:
-      semver-major-days: 14
-      semver-minor-days: 7
-      semver-patch-days: 1
+      default-days: 1
+      include:
+        - "*"
 
   - package-ecosystem: bundler
     directories:
@@ -38,9 +38,12 @@ updates:
         patterns:
           - "*"
     cooldown:
+      default-days: 1
       semver-major-days: 14
       semver-minor-days: 7
       semver-patch-days: 1
+      include:
+        - "*"
 
   - package-ecosystem: npm
     directory: /
@@ -56,9 +59,12 @@ updates:
         patterns:
           - "*"
     cooldown:
+      default-days: 1
       semver-major-days: 14
       semver-minor-days: 7
       semver-patch-days: 1
+      include:
+        - "*"
 
   - package-ecosystem: docker
     directory: /
@@ -73,10 +79,6 @@ updates:
       dependabot:
         patterns:
           - "*"
-    cooldown:
-      semver-major-days: 14
-      semver-minor-days: 7
-      semver-patch-days: 1
 
   - package-ecosystem: devcontainers
     directory: /
@@ -92,9 +94,12 @@ updates:
         patterns:
           - "*"
     cooldown:
+      default-days: 1
       semver-major-days: 14
       semver-minor-days: 7
       semver-patch-days: 1
+      include:
+        - "*"
 
   - package-ecosystem: pip
     directories:
@@ -112,6 +117,9 @@ updates:
         patterns:
           - "*"
     cooldown:
+      default-days: 1
       semver-major-days: 14
       semver-minor-days: 7
       semver-patch-days: 1
+      include:
+        - "*"


### PR DESCRIPTION
- GitHub Actions doesn't support semver cooldown.
- Docker doesn't support any cooldown.
- Use default days and include all packages so this actually works.
