### PR TITLE
github/dependabot: fix cooldown syntax (yet again).

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -95,9 +95,6 @@ updates:
           - "*"
     cooldown:
       default-days: 1
-      semver-major-days: 14
-      semver-minor-days: 7
-      semver-patch-days: 1
       include:
         - "*"
 


### PR DESCRIPTION
Devcontainers also don't support semver cooldown.
