### PR TITLE
sync-shared-config: sync to user-management repo

### DIFF
--- a/.github/workflows/sync-shared-config.yml
+++ b/.github/workflows/sync-shared-config.yml
@@ -52,10 +52,11 @@ jobs:
             Homebrew/homebrew-portable-ruby
             Homebrew/homebrew-test-bot
             Homebrew/install
-            Homebrew/ruby-macho
-            Homebrew/rubydoc.brew.sh
             Homebrew/mass-bottling-tracker-private
             Homebrew/private
+            Homebrew/ruby-macho
+            Homebrew/rubydoc.brew.sh
+            Homebrew/user-management
           )
           if [[ "${SKIP_PRIVATE}" == true ]]; then
             read -r -a repositories <<< "${repositories[@]//*private}"


### PR DESCRIPTION
We are not currently syncing to the user-management repo, which means it's constantly behind on GitHub Actions versions. Also alphabetized the repos.