### PR TITLE
dependabot: updates for Terraform

### DIFF
--- a/.github/actions/sync/dependabot.template.yml
+++ b/.github/actions/sync/dependabot.template.yml
@@ -11,17 +11,6 @@ multi-ecosystem-groups:
       timezone: "Etc/UTC"
 
 updates:
-  - package-ecosystem: github-actions
-    directory: /
-    multi-ecosystem-group: "all"
-    patterns: ["*"]
-    allow:
-      - dependency-type: all
-    cooldown:
-      default-days: 1
-      include:
-        - "*"
-
   - package-ecosystem: bundler
     directories:
       - /
@@ -38,6 +27,35 @@ updates:
       include:
         - "*"
 
+  - package-ecosystem: devcontainers
+    directory: /
+    multi-ecosystem-group: "all"
+    patterns: ["*"]
+    allow:
+      - dependency-type: all
+    cooldown:
+      default-days: 1
+      include:
+        - "*"
+
+  - package-ecosystem: docker
+    directory: /
+    multi-ecosystem-group: "all"
+    patterns: ["*"]
+    allow:
+      - dependency-type: all
+
+  - package-ecosystem: github-actions
+    directory: /
+    multi-ecosystem-group: "all"
+    patterns: ["*"]
+    allow:
+      - dependency-type: all
+    cooldown:
+      default-days: 1
+      include:
+        - "*"
+
   - package-ecosystem: npm
     directory: /
     multi-ecosystem-group: "all"
@@ -49,24 +67,6 @@ updates:
       semver-major-days: 14
       semver-minor-days: 7
       semver-patch-days: 1
-      include:
-        - "*"
-
-  - package-ecosystem: docker
-    directory: /
-    multi-ecosystem-group: "all"
-    patterns: ["*"]
-    allow:
-      - dependency-type: all
-
-  - package-ecosystem: devcontainers
-    directory: /
-    multi-ecosystem-group: "all"
-    patterns: ["*"]
-    allow:
-      - dependency-type: all
-    cooldown:
-      default-days: 1
       include:
         - "*"
 

--- a/.github/actions/sync/dependabot.template.yml
+++ b/.github/actions/sync/dependabot.template.yml
@@ -85,3 +85,10 @@ updates:
       semver-patch-days: 1
       include:
         - "*"
+
+  - package-ecosystem: terraform
+    directory: /
+    multi-ecosystem-group: "all"
+    patterns: ["*"]
+    allow:
+      - dependency-type: all

--- a/.github/actions/sync/shared-config.rb
+++ b/.github/actions/sync/shared-config.rb
@@ -75,12 +75,12 @@ dependabot_config_yaml["updates"] = dependabot_config_yaml["updates"].filter_map
   when "bundler"
     bundler_ecosystem = true
     "Gemfile.lock"
-  when "npm"
-    "package.json"
-  when "docker"
-    "Dockerfile"
   when "devcontainers"
     ".devcontainer/devcontainer.json"
+  when "docker"
+    "Dockerfile"
+  when "npm"
+    "package.json"
   when "pip"
     "requirements.txt"
   end

--- a/.github/actions/sync/shared-config.rb
+++ b/.github/actions/sync/shared-config.rb
@@ -83,6 +83,8 @@ dependabot_config_yaml["updates"] = dependabot_config_yaml["updates"].filter_map
     "package.json"
   when "pip"
     "requirements.txt"
+  when "terraform"
+    ".terraform.lock.hcl"
   end
 
   keep_update = if ecosystem_file && (update_directories = update["directories"])


### PR DESCRIPTION
Opened https://github.com/Homebrew/brew/pull/20315 in the wrong location, so now trying again in the correct repo.

I've split the commits here for easier review. I alphabetized the ecosystems in each file, and then added Terraform. This is needed for the user-management repo.