### PR TITLE
workflows/actionlint: remove `test-bot` Action input

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -37,7 +37,6 @@ jobs:
         with:
           core: false
           cask: false
-          test-bot: false
 
       - name: Install tools
         run: brew install actionlint shellcheck zizmor


### PR DESCRIPTION
`test-bot` has been merged into Homebrew/brew, so this is no longer necessary and outputs a warning in CI.