### PR TITLE
workflows/sync-shared-config: remove deprecated repos

### DIFF
--- a/.github/workflows/sync-shared-config.yml
+++ b/.github/workflows/sync-shared-config.yml
@@ -47,10 +47,8 @@ jobs:
             Homebrew/formulae.brew.sh
             Homebrew/glibc-bootstrap
             Homebrew/homebrew-cask
-            Homebrew/homebrew-command-not-found
             Homebrew/homebrew-core
             Homebrew/homebrew-portable-ruby
-            Homebrew/homebrew-test-bot
             Homebrew/install
             Homebrew/mass-bottling-tracker-private
             Homebrew/private


### PR DESCRIPTION
These have been merged into Homebrew/brew and are deprecated.