### PR TITLE
workflows/sync-shared-config: remove homebrew-portable-ruby.

### DIFF
--- a/.github/workflows/sync-shared-config.yml
+++ b/.github/workflows/sync-shared-config.yml
@@ -48,7 +48,6 @@ jobs:
             Homebrew/glibc-bootstrap
             Homebrew/homebrew-cask
             Homebrew/homebrew-core
-            Homebrew/homebrew-portable-ruby
             Homebrew/install
             Homebrew/mass-bottling-tracker-private
             Homebrew/private


### PR DESCRIPTION
This repository will shortly be archived.