### PR TITLE
stale-issues: add permission to update cache

### DIFF
--- a/.github/workflows/stale-issues.yml
+++ b/.github/workflows/stale-issues.yml
@@ -32,6 +32,7 @@ jobs:
       )
     runs-on: ubuntu-slim
     permissions:
+      actions: write
       contents: write
       issues: write
       pull-requests: write
@@ -62,6 +63,7 @@ jobs:
       )
     runs-on: ubuntu-slim
     permissions:
+      actions: write
       contents: write
       issues: write
       pull-requests: write


### PR DESCRIPTION
Our stale workflow hasn't been working correctly where stuff that has been stale for over a month is being ignored due to:
> pull request skipped due being processed during the previous run

I'm wondering if following is related https://github.com/Homebrew/homebrew-core/actions/runs/25615673189/job/75193146023#step:2:2467

> state: persisting info about 0 issue(s)
> Warning: Error delete _state: [403] Resource not accessible by integration - https://docs.github.com/rest/actions/cache#delete-github-actions-caches-for-a-repository-using-a-cache-key
> the state will be removed

So trying to add missing permissions to clear outdated cache.
- https://github.com/actions/stale#recommended-permissions

---

Wasn't sure if any alternative is possible to avoid the extra permissions.

There is upstream work on immutable cache but not available yet `https://github.com/actions/stale/pull/1237`