### PR TITLE
workflows/sync-shared-config: use main instead of stable

### DIFF
--- a/.github/workflows/sync-shared-config.yml
+++ b/.github/workflows/sync-shared-config.yml
@@ -71,6 +71,8 @@ jobs:
       - name: Set up Homebrew
         id: set-up-homebrew
         uses: Homebrew/actions/setup-homebrew@main
+        with:
+          stable: false
 
       - name: Set up Homebrew portable Ruby
         uses: Homebrew/actions/setup-ruby@main


### PR DESCRIPTION
This is blocking API regeneration. Let's use the `main` for now to unblock and reevaluate this after.