### PR TITLE
Sync brew.sh website theme

### DIFF
--- a/.github/actions/sync/shared-config.rb
+++ b/.github/actions/sync/shared-config.rb
@@ -15,14 +15,22 @@ def git(*args)
 end
 # rubocop:enable Style/TopLevelMethodDefinition
 
-target_directory = ARGV.fetch(0, "")
-target_directory_path = Pathname(target_directory)
-repository_name = target_directory_path.basename.to_s
-homebrew_repository_path = Pathname(ARGV.fetch(1, ""))
-
-if !target_directory_path.directory? || !homebrew_repository_path.directory? || ARGV[2]
-  abort "Usage: #{$PROGRAM_NAME} <target_directory_path> <homebrew_repository_path>"
+if ARGV[0].to_s.empty? || ARGV[1].to_s.empty? || ARGV[3]
+  abort "Usage: #{$PROGRAM_NAME} <target_directory_path> <homebrew_repository_path> [brewsh_repository_path]"
 end
+
+target_directory = ARGV.fetch(0)
+target_directory_path = Pathname(target_directory).expand_path
+repository_name = target_directory_path.basename.to_s
+homebrew_repository_path = Pathname(ARGV.fetch(1)).expand_path
+
+brewsh_repository = ARGV.fetch(2, "")
+brewsh_repository_path = Pathname(brewsh_repository).expand_path unless brewsh_repository.empty?
+
+if !target_directory_path.directory? || !homebrew_repository_path.directory?
+  abort "Usage: #{$PROGRAM_NAME} <target_directory_path> <homebrew_repository_path> [brewsh_repository_path]"
+end
+abort "#{brewsh_repository_path} is not a directory" if brewsh_repository_path && !brewsh_repository_path.directory?
 
 docs = "docs"
 ruby_version = ".ruby-version"
@@ -35,6 +43,14 @@ actionlint_workflow_yaml = ".github/workflows/actionlint.yml"
 stale_issues_workflow_yaml = ".github/workflows/stale-issues.yml"
 zizmor_yml = ".github/zizmor.yml"
 codeql_extensions_homebrew_actions_yml = ".github/codeql/extensions/homebrew-actions.yml"
+brewsh_theme_paths = %w[
+  _includes
+  _layouts
+  _sass
+  assets/css
+  assets/img
+  bin/jekyll
+].freeze
 
 homebrew_docs = homebrew_repository_path/docs
 homebrew_ruby_version =
@@ -168,6 +184,9 @@ puts "Detecting changes…"
       next if rejected_docs_basenames.include?(docs_path_basename)
 
       docs_path_subpath = docs_path.to_s.delete_prefix("#{homebrew_docs}/")
+      next if docs_path_subpath.start_with?("_includes/", "_layouts/", "_sass/", "assets/css/", "bin/jekyll")
+      next if docs_path_subpath.start_with?("assets/img/") && !docs_path_subpath.start_with?("assets/img/docs/")
+
       target_docs_path = target_path/docs_path_subpath
       next if docs_path.extname == ".png"
       next if docs_path.extname == ".md" && !target_docs_path.exist?
@@ -260,6 +279,49 @@ puts "Detecting changes…"
     next if path == target_path.to_s
 
     FileUtils.cp path, target_path
+  end
+end
+
+if brewsh_repository_path
+  theme_site_path = case repository_name
+  when "brew.sh", "formulae.brew.sh"
+    target_directory_path
+  else
+    target_docs_path = target_directory_path/docs
+    target_docs_path if target_docs_path.directory?
+  end
+
+  if theme_site_path
+    brewsh_theme_paths.each do |theme_path|
+      source_path = brewsh_repository_path/theme_path
+      next unless source_path.exist?
+
+      if source_path.directory?
+        Find.find(source_path.to_s) do |path|
+          path = Pathname(path)
+          if path.directory?
+            next Find.prune if theme_path == "assets/img" && path.basename.to_s == "blog"
+
+            next
+          end
+
+          relative_path = path.to_s.delete_prefix("#{source_path}/")
+          target_path = theme_site_path/theme_path/relative_path
+          next if path == target_path
+
+          target_path.dirname.mkpath
+          FileUtils.cp path, target_path
+          FileUtils.chmod path.stat.mode, target_path
+        end
+      else
+        target_path = theme_site_path/theme_path
+        next if source_path == target_path
+
+        target_path.dirname.mkpath
+        FileUtils.cp source_path, target_path
+        FileUtils.chmod source_path.stat.mode, target_path
+      end
+    end
   end
 end
 

--- a/.github/workflows/sync-shared-config.yml
+++ b/.github/workflows/sync-shared-config.yml
@@ -59,9 +59,37 @@ jobs:
             read -r -a repositories <<< "${repositories[@]//*private}"
           fi
           echo "matrix=$(jq -cn '$ARGS.positional' --args -- "${repositories[@]}")" >> "${GITHUB_OUTPUT}"
+  style:
+    if: github.repository == 'Homebrew/.github'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Homebrew
+        id: set-up-homebrew
+        uses: Homebrew/actions/setup-homebrew@main
+        with:
+          stable: false
+
+      - name: Set up Homebrew portable Ruby
+        uses: Homebrew/actions/setup-ruby@main
+        with:
+          portable-ruby: true
+
+      - name: Clone source repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - run: brew install-bundler-gems --groups=style
+        env:
+          HOMEBREW_DEVELOPER: 1
+
+      - run: brew style .github/actions/sync/*.rb
+        env:
+          HOMEBREW_DEVELOPER: 1
+
   sync:
     if: github.repository == 'Homebrew/.github'
-    needs: generate-matrix
+    needs: [generate-matrix, style]
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -84,15 +112,19 @@ jobs:
         with:
           persist-credentials: false
 
-      - run: brew install-bundler-gems --groups=style
-        if: matrix.repo == 'Homebrew/.github'
-        env:
-          HOMEBREW_DEVELOPER: 1
-
-      - run: brew style .github/actions/sync/*.rb
-        if: matrix.repo == 'Homebrew/.github'
-        env:
-          HOMEBREW_DEVELOPER: 1
+      - name: Clone brew.sh source repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: Homebrew/brew.sh
+          path: source/brew.sh
+          persist-credentials: false
+          sparse-checkout: |
+            _includes
+            _layouts
+            _sass
+            assets/css
+            assets/img
+            bin
 
       - name: Clone target repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -121,7 +153,7 @@ jobs:
         id: detect_changes
         env:
           TARGET: target/${{ matrix.repo }}
-        run: ./.github/actions/sync/shared-config.rb "${TARGET}" '/home/linuxbrew/.linuxbrew/Homebrew'
+        run: ./.github/actions/sync/shared-config.rb "${TARGET}" '/home/linuxbrew/.linuxbrew/Homebrew' source/brew.sh
 
       - name: Create pull request
         if: (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && steps.detect_changes.outputs.pull_request == 'true'


### PR DESCRIPTION
Depends on https://github.com/Homebrew/brew.sh/pull/1305

- Copy shared Jekyll theme files from `Homebrew/brew.sh`.
- Keep `brew.sh` and `formulae.brew.sh` rooted at the site root.
- Sync other documentation sites into their `docs` directory.
- Preserve copied file modes so `bin/jekyll` remains executable.
- Expand input paths before `chdir` so local syncs are stable.
- Avoid copying theme files through the existing docs sync path.