### PR TITLE
Fix template checker sync

### DIFF
--- a/.github/actions/sync/shared-config.rb
+++ b/.github/actions/sync/shared-config.rb
@@ -290,13 +290,9 @@ puts "Detecting changes…"
     )
   when check_template_rb
     next if path == target_path.to_s
+    next if repository_name == ".github"
 
-    if template_check_repositories.none?(repository_name)
-      FileUtils.rm_f target_path
-      next
-    end
-
-    FileUtils.cp path, target_path
+    FileUtils.rm_f target_path
   when deprecated_lock_threads
     next unless target_path.exist?
 

--- a/.github/workflows/check-issues.yml
+++ b/.github/workflows/check-issues.yml
@@ -71,7 +71,7 @@ jobs:
 
       - name: Fetch template checker
         run: |
-          gh api "repos/${GITHUB_REPOSITORY:?}/contents/.github/scripts/check_template.rb?ref=main" \
+          gh api "repos/Homebrew/.github/contents/.github/scripts/check_template.rb?ref=main" \
             --jq ".content" |
             base64 --decode >"${RUNNER_TEMP:?}/check_template.rb"
 

--- a/.github/workflows/check-prs.yml
+++ b/.github/workflows/check-prs.yml
@@ -70,7 +70,7 @@ jobs:
 
       - name: Fetch template checker
         run: |
-          gh api "repos/${GITHUB_REPOSITORY:?}/contents/.github/scripts/check_template.rb?ref=main" \
+          gh api "repos/Homebrew/.github/contents/.github/scripts/check_template.rb?ref=main" \
             --jq ".content" |
             base64 --decode >"${RUNNER_TEMP:?}/check_template.rb"
 


### PR DESCRIPTION
- Keep `check_template.rb` owned by `Homebrew/.github` instead of syncing it into target repositories.
- Fetch the checker from `Homebrew/.github` in synced workflows so targets use shared trusted code.
- Remove stranded checker copies from synced target repositories.