### PR TITLE
Stop archived brew-rs sync

### DIFF
--- a/.github/workflows/sync-shared-config.yml
+++ b/.github/workflows/sync-shared-config.yml
@@ -51,7 +51,6 @@ jobs:
             Homebrew/private
             Homebrew/ruby-macho
             Homebrew/homebrew-brew-vulns
-            Homebrew/brew-rs-private
             Homebrew/BrewUI
             Homebrew/patchelf.rb
           )


### PR DESCRIPTION
`Homebrew/brew-rs-private` is archived, so syncing it breaks.