### PR TITLE
.github/workflows/check-prs.yml: allow use of `brew bump`

### DIFF
--- a/.github/workflows/check-prs.yml
+++ b/.github/workflows/check-prs.yml
@@ -77,6 +77,17 @@ jobs:
       - name: Check pull request template
         id: template
         run: |
+          # homebrew-core and homebrew-cask allow a condensed PR body when opened by brew bump.
+          if [[ "${GITHUB_REPOSITORY}" == "Homebrew/homebrew-core" ||
+                "${GITHUB_REPOSITORY}" == "Homebrew/homebrew-cask" ]]
+          then
+            if grep -qE "Created by \`brew bump(-cask-pr|-formula-pr)?\`" "${RUNNER_TEMP}/check-prs/body"
+            then
+              echo "complete_template=true" >>"${GITHUB_OUTPUT:?}"
+              exit 0
+            fi
+          fi
+
           complete_template="$(
             ruby "${RUNNER_TEMP:?}/check_template.rb" pull-request \
               "${RUNNER_TEMP}/check-prs/body" \

--- a/.github/workflows/check-prs.yml
+++ b/.github/workflows/check-prs.yml
@@ -81,7 +81,7 @@ jobs:
           if [[ "${GITHUB_REPOSITORY}" == "Homebrew/homebrew-core" ||
                 "${GITHUB_REPOSITORY}" == "Homebrew/homebrew-cask" ]]
           then
-            if grep -qE "Created by \`brew bump(-cask-pr|-formula-pr)?\`" "${RUNNER_TEMP}/check-prs/body"
+            if grep -qE 'Created (with|by) `brew bump(-cask-pr|-formula-pr)?`' "${RUNNER_TEMP}/check-prs/body"
             then
               echo "complete_template=true" >>"${GITHUB_OUTPUT:?}"
               exit 0


### PR DESCRIPTION
Allow the use of `brew bump` and `brew bump-(cask|formula)-pr` in `homebrew-cask` and `homebrew-core`.

The early exit is included in the `check-prs` workflow because it allows scoping this to the appropriate repositories, if we don't care about this, can update the PR to include it in the check script instead.