### PR TITLE
shared-config: avoid collapsing renames during sync commits

### DIFF
--- a/.github/actions/sync/shared-config.rb
+++ b/.github/actions/sync/shared-config.rb
@@ -552,7 +552,7 @@ end
 
 git "-C", target_directory, "add", "--all"
 
-out, err, status = Open3.capture3("git", "-C", target_directory, "diff", "--name-only", "--staged")
+out, err, status = Open3.capture3("git", "-C", target_directory, "diff", "--name-only", "--staged", "--no-renames")
 raise err unless status.success?
 
 modified_paths = out.lines.map(&:chomp)


### PR DESCRIPTION
Use `git diff --no-renames` when collecting staged paths so a synced delete/add pair is committed as separate paths. This keeps deprecated workflow removals in the same sync run that adds their replacement.

For context, this fixes an issue where the rename of the stale-issues-and-prs workflow could not be done in a single sync, like:

- https://github.com/Homebrew/brew/pull/22914 (`stale-issues-and-prs.yml` was added)
- https://github.com/Homebrew/brew/pull/23011 (`stale-issues.yml` was removed)
