### PR TITLE
sync-shared-config: use deterministic backoff

### DIFF
--- a/.github/workflows/sync-shared-config.yml
+++ b/.github/workflows/sync-shared-config.yml
@@ -147,8 +147,8 @@ jobs:
           cd "target/$GH_REPO"
           git checkout -b sync-shared-config
 
-          # Stagger network calls over the next 10 minutes to minimise errors.
-          sleep "$(( RANDOM % 60 * 10 ))"
+          # Stagger network calls to minimise errors.
+          sleep "$(( JOB_INDEX * 5 ))"
           if gh api \
               -X GET \
               --header 'Accept: application/vnd.github+json' \
@@ -172,6 +172,7 @@ jobs:
         env:
           GH_REPO: ${{ matrix.repo }}
           GH_TOKEN: ${{ secrets.HOMEBREW_DOTGITHUB_WORKFLOW_TOKEN }}
+          JOB_INDEX: ${{ strategy.job-index }}
   conclusion:
     needs: sync
     runs-on: ubuntu-slim


### PR DESCRIPTION
We can use `strategy.job-index` [^1] to help to determine the backoff time for each job in the matrix. This will help to arrange the jobs in the matrix more deterministically and efficiently than using a random backoff, while still avoiding hitting rate limits.

[^1]: https://docs.github.com/en/actions/reference/workflows-and-actions/contexts#strategy-context
