### PR TITLE
Add synced licence workflow

### DIFF
--- a/.github/actions/sync/shared-config.rb
+++ b/.github/actions/sync/shared-config.rb
@@ -49,6 +49,7 @@ rubocop_yaml = ".rubocop.yml"
 vale_ini = ".vale.ini"
 dependabot_template_yaml = ".github/actions/sync/dependabot.template.yml"
 dependabot_yaml = ".github/dependabot.yml"
+denied_licenses_txt = ".github/denied-licenses.txt"
 check_template_rb = ".github/scripts/check_template.rb"
 docs_workflow_yaml = ".github/workflows/docs.yml"
 actionlint_workflow_yaml = ".github/workflows/actionlint.yml"
@@ -58,6 +59,12 @@ check_workflow_yamls = [
   check_issues_workflow_yaml,
   check_prs_workflow_yaml,
 ].freeze
+licenses_workflow_yaml = ".github/workflows/licenses.yml"
+license_check_paths = [
+  denied_licenses_txt,
+  licenses_workflow_yaml,
+].freeze
+license_package_ecosystems = %w[bundler cargo npm pip].freeze
 stale_issues_and_prs_workflow_yaml = ".github/workflows/stale-issues-and-prs.yml"
 codeql_extensions_homebrew_actions_yml = ".github/codeql/extensions/homebrew-actions.yml"
 brewsh_assets_url = "https://brew.sh"
@@ -140,6 +147,9 @@ dependabot_config_yaml["updates"] = dependabot_config_yaml["updates"].filter_map
 
   update
 end
+licenses_enabled = dependabot_config_yaml["updates"].any? do |update|
+  license_package_ecosystems.include?(update["package-ecosystem"])
+end
 dependabot_config = dependabot_config_yaml.to_yaml
 
 custom_ruby_version_repos = %w[
@@ -173,6 +183,7 @@ puts "Detecting changes…"
   ruby_version,
   rubocop_yaml,
   dependabot_yaml,
+  *license_check_paths,
   check_template_rb,
   deprecated_zizmor_yml,
   actionlint_workflow_yaml,
@@ -268,8 +279,8 @@ puts "Detecting changes…"
       "# This file is synced from `Homebrew/brew` by the `.github` repository, do not modify it directly.\n" \
       "#{homebrew_rubocop_config}\n",
     )
-  when dependabot_yaml, actionlint_workflow_yaml, check_issues_workflow_yaml, check_prs_workflow_yaml,
-       stale_issues_and_prs_workflow_yaml,
+  when dependabot_yaml, denied_licenses_txt, licenses_workflow_yaml, actionlint_workflow_yaml,
+       check_issues_workflow_yaml, check_prs_workflow_yaml, stale_issues_and_prs_workflow_yaml,
        codeql_extensions_homebrew_actions_yml
     contents = if path == dependabot_yaml
       dependabot_config
@@ -278,6 +289,11 @@ puts "Detecting changes…"
 
       # ensure we don't replace the non-dependabot template files in this repository
       next if repository_name == ".github"
+
+      if license_check_paths.include?(path) && !licenses_enabled
+        FileUtils.rm_f target_path
+        next
+      end
 
       if check_workflow_yamls.include?(path) && template_check_repositories.none?(repository_name)
         FileUtils.rm_f target_path

--- a/.github/denied-licenses.txt
+++ b/.github/denied-licenses.txt
@@ -1,0 +1,5 @@
+# SPDX licences denied for every dependency ecosystem.
+AGPL-1.0-only
+AGPL-1.0-or-later
+AGPL-3.0-only
+AGPL-3.0-or-later

--- a/.github/workflows/licenses.yml
+++ b/.github/workflows/licenses.yml
@@ -1,0 +1,95 @@
+name: Licenses
+
+on:
+  push:
+    branches:
+      - main
+      - master
+  pull_request:
+  merge_group:
+
+permissions:
+  actions: write
+  contents: read
+
+defaults:
+  run:
+    shell: bash -euo pipefail {0}
+
+jobs:
+  licenses:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Set up Homebrew
+        uses: Homebrew/actions/setup-homebrew@df4b09108a1de9d6f995fe68f302b3f68bd6d2ef # 2026.07.20.1
+
+      - name: Install git-pkgs
+        run: brew install git-pkgs
+
+      - name: Cache git-pkgs licence metadata
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ${{ runner.temp }}/git-pkgs
+          key: git-pkgs-metadata-v1-${{ hashFiles('**/Gemfile.lock', '**/Cargo.toml', '**/Cargo.lock', '**/package.json', '**/package-lock.json', '**/requirements.txt') }}
+          restore-keys: git-pkgs-metadata-v1-
+
+      - name: Read denied licences
+        run: |
+          if [[ ! -f .github/denied-licenses.txt ]]; then
+            echo "::error::.github/denied-licenses.txt is required."
+            exit 1
+          fi
+          denied="$(sed -E \
+            '/^[[:space:]]*(#|$)/d; s/^[[:space:]]*//; s/[[:space:]]*$//' \
+            .github/denied-licenses.txt | paste -sd, -)"
+          if [[ -z "${denied}" ]]; then
+            echo "::error::.github/denied-licenses.txt must contain at least one licence."
+            exit 1
+          fi
+          echo "Denied licences: ${denied}"
+          echo "DENIED_LICENSES=${denied}" >> "${GITHUB_ENV}"
+
+      - name: Check licences
+        env:
+          GIT_PKGS_DB: ${{ runner.temp }}/git-pkgs/metadata.db
+          # Identify ecosyste.ms requests for its polite pool:
+          # https://github.com/git-pkgs/git-pkgs#configuration
+          GIT_PKGS_ECOSYSTEMS_FROM: leads@brew.sh
+        run: |
+          output="${RUNNER_TEMP}/licenses.json"
+          stderr="${RUNNER_TEMP}/licenses.stderr"
+          status=0
+          git \
+            -c pkgs.ecosystems=cargo \
+            -c pkgs.ecosystems=docker \
+            -c pkgs.ecosystems=rubygems \
+            -c pkgs.ecosystems=github-actions \
+            -c pkgs.ecosystems=npm \
+            -c pkgs.ecosystems=pypi \
+            pkgs licenses --format=json --deny="${DENIED_LICENSES}" \
+            > "${output}" 2> "${stderr}" || status="$?"
+          if ! jq -e 'type == "array"' "${output}" &>/dev/null; then
+            echo "git pkgs licenses failed:"
+            cat "${stderr}"
+            cat "${output}"
+            if ((status == 0)); then
+              exit 1
+            fi
+            exit "${status}"
+          fi
+
+          violations="$(jq -r \
+            '.[] | select(.flagged) | . as $dep |
+            "\($dep.name) (\($dep.ecosystem)) \($dep.version // "?"): \($dep.licenses | join(", ")) - \($dep.flag_reason)"' \
+            "${output}")"
+          if [ -n "${violations}" ]; then
+            echo "Dependencies with denied licences:"
+            echo "${violations}"
+            exit 1
+          fi
+          echo "No denied licences found in $(jq length "${output}") dependencies."


### PR DESCRIPTION
- Check dependency licences from a centrally managed workflow.
- Sync to repositories with Bundler, Cargo, npm or pip manifests.
- Sync the shared denylist alongside the workflow.