### PR TITLE
Limit licence checks to dependency changes

### DIFF
--- a/.github/workflows/licenses.yml
+++ b/.github/workflows/licenses.yml
@@ -6,6 +6,15 @@ on:
       - main
       - master
   pull_request:
+    paths:
+      - "**/Cargo.lock"
+      - "**/Cargo.toml"
+      - "**/Gemfile.lock"
+      - "**/package-lock.json"
+      - "**/package.json"
+      - "**/requirements.txt"
+      - .github/denied-licenses.txt
+      - .github/workflows/licenses.yml
   merge_group:
 
 permissions:


### PR DESCRIPTION
This should stop us spamming ecosyste.ms quite as hard as are.