### PR TITLE
sync: support the uv dependabot ecosystem

### DIFF
--- a/.github/actions/sync/dependabot.template.yml
+++ b/.github/actions/sync/dependabot.template.yml
@@ -138,3 +138,20 @@ updates:
       - dependency-type: all
     cooldown:
       default-days: 7
+
+  - package-ecosystem: uv
+    directories:
+      - /
+      - /Library/Homebrew/formula-analytics/
+    schedule:
+      interval: weekly
+      day: "monday"
+      time: "08:00"
+      timezone: "Etc/UTC"
+    groups:
+      uv:
+        patterns: ["*"]
+    allow:
+      - dependency-type: all
+    cooldown:
+      default-days: 7

--- a/.github/actions/sync/shared-config.rb
+++ b/.github/actions/sync/shared-config.rb
@@ -123,6 +123,8 @@ dependabot_config_yaml["updates"] = dependabot_config_yaml["updates"].filter_map
     "requirements.txt"
   when "opentofu"
     ".terraform.lock.hcl"
+  when "uv"
+    "uv.lock"
   end
 
   keep_update = if (update_directories = update["directories"])


### PR DESCRIPTION
Needs https://github.com/Homebrew/brew/pull/23379

- Homebrew repositories are standardising Python tooling on `uv`: `brew formula-analytics` now manages its dependencies with `pyproject.toml` and `uv.lock`, so sync a `uv` dependabot entry to any repository with a `uv.lock` in a known directory.
- The `pip` ecosystem entry remains for any repository that still uses `requirements.txt`; it filters itself out everywhere else.