### PR TITLE
Sync shared Jekyll bootstrap

### DIFF
--- a/.github/actions/sync/shared-config.rb
+++ b/.github/actions/sync/shared-config.rb
@@ -67,6 +67,10 @@ license_check_paths = [
 license_package_ecosystems = %w[bundler cargo npm pip].freeze
 stale_issues_and_prs_workflow_yaml = ".github/workflows/stale-issues-and-prs.yml"
 codeql_extensions_homebrew_actions_yml = ".github/codeql/extensions/homebrew-actions.yml"
+shared_jekyll_paths = %w[
+  bin/jekyll
+  script/bootstrap
+].freeze
 brewsh_assets_url = "https://brew.sh"
 
 homebrew_docs = homebrew_repository_path/docs
@@ -211,7 +215,7 @@ puts "Detecting changes…"
       next if rejected_docs_basenames.include?(docs_path_basename)
 
       docs_path_subpath = docs_path.to_s.delete_prefix("#{homebrew_docs}/")
-      next if docs_path_subpath.start_with?("_includes/", "_layouts/", "_sass/", "assets/css/", "bin/jekyll")
+      next if docs_path_subpath.start_with?("_includes/", "_layouts/", "_sass/", "assets/css/", *shared_jekyll_paths)
       next if docs_path_subpath.start_with?("assets/img/") && !docs_path_subpath.start_with?("assets/img/docs/")
 
       target_docs_path = target_path/docs_path_subpath
@@ -347,8 +351,9 @@ if brewsh_repository_path && repository_name != "brew.sh"
       end
     end
 
-    bin_jekyll = "bin/jekyll"
-    shared_theme_paths << bin_jekyll if (brewsh_repository_path/bin_jekyll).file?
+    shared_jekyll_paths.each do |path|
+      shared_theme_paths << path if (brewsh_repository_path/path).file?
+    end
 
     read_front_matter = lambda do |path|
       next {} unless path.file?
@@ -393,7 +398,7 @@ if brewsh_repository_path && repository_name != "brew.sh"
       required_layouts << read_front_matter.call(path)["layout"]
     end
 
-    theme_paths = [bin_jekyll]
+    theme_paths = shared_jekyll_paths.dup
     seen_layouts = []
     until required_layouts.empty?
       layout = required_layouts.shift

--- a/.github/workflows/sync-shared-config.yml
+++ b/.github/workflows/sync-shared-config.yml
@@ -111,6 +111,7 @@ jobs:
             _includes
             _layouts
             bin
+            script
 
       - name: Clone target repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1


### PR DESCRIPTION
- Copy `script/bootstrap` with the shared Jekyll launcher.
- Include the source script in the sparse checkout.