### PR TITLE
Require completed PR templates from humans

### DIFF
--- a/.github/workflows/check-prs.yml
+++ b/.github/workflows/check-prs.yml
@@ -36,7 +36,6 @@ jobs:
       pull-requests: write
     env:
       GH_TOKEN: ${{ github.token }}
-      PR_AUTHOR_ASSOCIATION: ${{ github.event.pull_request.author_association }}
       PR_NUMBER: ${{ github.event.pull_request.number }}
       PR_TEMPLATE_URL: ${{ github.server_url }}/${{ github.repository }}/blob/main/.github/PULL_REQUEST_TEMPLATE.md
     steps:
@@ -78,13 +77,6 @@ jobs:
       - name: Check pull request template
         id: template
         run: |
-          case "${PR_AUTHOR_ASSOCIATION}" in
-            OWNER | MEMBER | COLLABORATOR | CONTRIBUTOR)
-              echo "complete_template=true" >>"${GITHUB_OUTPUT:?}"
-              exit 0
-              ;;
-          esac
-
           # homebrew-core and homebrew-cask allow condensed PR bodies from recognised bump tools.
           if [[ "${GITHUB_REPOSITORY}" == "Homebrew/homebrew-core" ||
                 "${GITHUB_REPOSITORY}" == "Homebrew/homebrew-cask" ]]
@@ -160,7 +152,7 @@ jobs:
             --raw-field body="$(
               cat <<COMMENT
           <!-- incomplete-pr-template -->
-          Thanks for your pull request. This has been closed because it appears to use an incomplete or outdated pull request template.
+          Thanks for your pull request. This has been closed because it appears to be missing the pull request template, perhaps because this was written by an AI not a human. We require humans to read and fill in these templates.
 
           Please edit this pull request to fill in the current [pull request template](${PR_TEMPLATE_URL:?}). This workflow will reopen this pull request automatically once the template is complete. **Do not open a new pull request for this.**
           COMMENT


### PR DESCRIPTION
- Author association exemptions from `c7aef89` let `OWNER`, `MEMBER`, `COLLABORATOR` and `CONTRIBUTOR` PRs skip the template check but every human should complete the template.
- Keep only the bot and recognised bump tool exemptions.
- Tell authors of incomplete PRs that the template may be missing because an AI wrote the description and we require humans to read and fill in these templates.