### PR TITLE
dependabot: exclude Homebrew/actions from cooldown

### DIFF
--- a/.github/actions/sync/dependabot.template.yml
+++ b/.github/actions/sync/dependabot.template.yml
@@ -85,6 +85,8 @@ updates:
       - dependency-type: all
     cooldown:
       default-days: 7
+      exclude:
+        - "Homebrew/actions/*"
 
   - package-ecosystem: npm
     directory: /


### PR DESCRIPTION
We don't need a cooldown on our first-party Actions. All of the dependencies in them have their own cooldowns. This reduces our own updates from 11 days after tag, to 4.