### PR TITLE
Allow canonical reverts without templates

### DIFF
--- a/.github/scripts/check_template.rb
+++ b/.github/scripts/check_template.rb
@@ -31,6 +31,13 @@ end
 
 case ARGV.fetch(0)
 when "pull-request"
+  repository = ARGV[4]
+  if repository && !repository.empty? && ARGV.fetch(3, "").match?(/\ARevert ".+"\z/) &&
+     File.read(ARGV.fetch(1), mode: "rb").rstrip.match?(/\AReverts #{Regexp.escape(repository)}#\d+\z/)
+    puts true
+    exit
+  end
+
   # Pass when the body keeps at least REQUIRED_TEMPLATE_PERCENTAGE of the template's
   # headings and checkboxes combined (ticked or not) and still discloses AI usage:
   # either the template's AI disclosure checkbox (whose label mentions AI) or any
@@ -92,7 +99,7 @@ when "issue"
     end
   end
 else
-  warn "Usage: check_template.rb pull-request BODY TEMPLATE"
+  warn "Usage: check_template.rb pull-request BODY TEMPLATE [TITLE REPOSITORY]"
   warn "       check_template.rb issue BODY TEMPLATE_DIRECTORY REPOSITORY"
   exit 1
 end

--- a/.github/workflows/check-prs.yml
+++ b/.github/workflows/check-prs.yml
@@ -76,6 +76,8 @@ jobs:
 
       - name: Check pull request template
         id: template
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
           # homebrew-core and homebrew-cask allow condensed PR bodies from recognised bump tools.
           if [[ "${GITHUB_REPOSITORY}" == "Homebrew/homebrew-core" ||
@@ -92,7 +94,9 @@ jobs:
           complete_template="$(
             ruby "${RUNNER_TEMP:?}/check_template.rb" pull-request \
               "${RUNNER_TEMP}/check-prs/body" \
-              "${RUNNER_TEMP}/check-prs/template"
+              "${RUNNER_TEMP}/check-prs/template" \
+              "${PR_TITLE}" \
+              "${GITHUB_REPOSITORY:?}"
           )"
           case "${complete_template}" in
             true | false) ;;


### PR DESCRIPTION
- Exempt GitHub-generated revert pull requests from template checks.
- Require matching title and same-repository body formats to keep the exemption narrow.