### PR TITLE
check_template: allow extended revert descriptions

### DIFF
--- a/.github/scripts/check_template.rb
+++ b/.github/scripts/check_template.rb
@@ -33,7 +33,7 @@ case ARGV.fetch(0)
 when "pull-request"
   repository = ARGV[4]
   if repository && !repository.empty? && ARGV.fetch(3, "").match?(/\ARevert ".+"\z/) &&
-     File.read(ARGV.fetch(1), mode: "rb").rstrip.match?(/\AReverts #{Regexp.escape(repository)}#\d+\z/)
+     File.read(ARGV.fetch(1), mode: "rb").match?(/\A\s*Reverts #{Regexp.escape(repository)}#\d+\r?$/)
     puts true
     exit
   end


### PR DESCRIPTION
A recent change (https://github.com/Homebrew/.github/pull/472) added an exception to the PR template check to allow for reverts created via the GitHub UI. The regex required an exact match, so if a written description for the revert is provided the PR gets closed. This change is at the risk of the allowance being too broad, but I wouldn't expect this to be actively exploited.